### PR TITLE
Add symfony/var-exporter to fix Doctrine LazyGhost error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
         "symfony/messenger": "^7.1",
         "symfony/monolog-bundle": "^3.0",
         "symfony/property-access": "^7.1",
-
         "symfony/runtime": "^7.1",
         "symfony/serializer": "^7.1",
         "symfony/string": "^7.1",
         "symfony/twig-bridge": "^7.1",
+        "symfony/var-exporter": "^7.1",
         "symfony/webpack-encore-bundle": "^2.0",
         "symfony/yaml": "^7.1",
         "twig/extra-bundle": "^2.12|^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "442dc2b1aeb524c8da80309b98d9c34a",
+    "content-hash": "a7f55961410c8d4b85f953d516a9059b",
     "packages": [
         {
             "name": "calderacc/geobasic",
@@ -11167,25 +11167,26 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.1.2",
+            "version": "v7.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "b80a669a2264609f07f1667f891dbfca25eba44c"
+                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/b80a669a2264609f07f1667f891dbfca25eba44c",
-                "reference": "b80a669a2264609f07f1667f891dbfca25eba44c",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/03a60f169c79a28513a78c967316fbc8bf17816f",
+                "reference": "03a60f169c79a28513a78c967316fbc8bf17816f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
-                "symfony/property-access": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -11223,7 +11224,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.1.2"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.0"
             },
             "funding": [
                 {
@@ -11235,11 +11236,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T08:00:31+00:00"
+            "time": "2025-09-11T10:15:23+00:00"
         },
         {
             "name": "symfony/webpack-encore-bundle",
@@ -12738,5 +12743,5 @@
         "composer-plugin-api": "^2.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary
- Adds `symfony/var-exporter` ^7.1 as explicit dependency
- Fixes `cache:clear` failure caused by missing LazyGhost support in Doctrine ORM 3.x

## Context
Without this package, the application fails with:
```
Symfony LazyGhost is not available. Please install the "symfony/var-exporter" package version 6.4 or 7
```

## Test plan
- [ ] Run `composer install` on the server
- [ ] Verify `cache:clear` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)