### PR TITLE
Fix refreshMaterializedView() to refresh all views

### DIFF
--- a/src/Repository/DataRepository.php
+++ b/src/Repository/DataRepository.php
@@ -126,11 +126,10 @@ LIMIT 10';
 
     public function refreshMaterializedView(): void
     {
-        $sql = 'REFRESH MATERIALIZED VIEW data_view;';
-        $sql = 'REFRESH MATERIALIZED VIEW silvester_data;';
-        $sql = 'REFRESH MATERIALIZED VIEW current_data;';
+        $connection = $this->getEntityManager()->getConnection();
 
-        $query = $this->getEntityManager()->createNativeQuery($sql, new ResultSetMapping());
-        $query->getResult();
+        $connection->executeStatement('REFRESH MATERIALIZED VIEW data_view');
+        $connection->executeStatement('REFRESH MATERIALIZED VIEW silvester_data');
+        $connection->executeStatement('REFRESH MATERIALIZED VIEW current_data');
     }
 }


### PR DESCRIPTION
## Summary
- Fix critical bug where only `current_data` materialized view was refreshed
- `data_view` and `silvester_data` were never refreshed due to `$sql` variable being overwritten
- Use `executeStatement()` instead of native queries for DDL statements

## Problem
```php
// Before: only last assignment executes
$sql = 'REFRESH MATERIALIZED VIEW data_view;';
$sql = 'REFRESH MATERIALIZED VIEW silvester_data;';  // overwrites
$sql = 'REFRESH MATERIALIZED VIEW current_data;';    // overwrites again
```

## Test plan
- [ ] Run `php bin/console luft:refresh` and verify all three views are refreshed
- [ ] Check that Silvester analysis and data_view queries return current data

🤖 Generated with [Claude Code](https://claude.com/claude-code)