### PR TITLE
Fix isIndexable() DateTimeImmutable bug

### DIFF
--- a/src/Entity/Data.php
+++ b/src/Entity/Data.php
@@ -112,10 +112,9 @@ class Data
 
     public function isIndexable(): bool
     {
-        $dateTime = new \DateTimeImmutable();
-        $dateTime->sub(new \DateInterval('P1W'));
+        $oneWeekAgo = (new \DateTimeImmutable())->sub(new \DateInterval('P1W'));
 
-        return $dateTime >= $this->dateTime;
+        return $oneWeekAgo >= $this->dateTime;
     }
 
     public function getTag(): ?string


### PR DESCRIPTION
## Summary
- Fix bug where `DateTimeImmutable::sub()` return value was discarded
- Method was always comparing against "now" instead of "one week ago"

## Problem
```php
// Before: sub() return value lost
$dateTime = new \DateTimeImmutable();
$dateTime->sub(new \DateInterval('P1W')); // returns new object, ignored
return $dateTime >= $this->dateTime;      // always compares with "now"
```

## Test plan
- [ ] Verify that `isIndexable()` correctly returns `true` only for data older than 1 week

🤖 Generated with [Claude Code](https://claude.com/claude-code)