### PR TITLE
Add unique constraint to prevent duplicate measurement data

### DIFF
--- a/src/Air/DataPersister/PostgisPersister.php
+++ b/src/Air/DataPersister/PostgisPersister.php
@@ -5,6 +5,7 @@ namespace App\Air\DataPersister;
 use App\Air\StationCache\StationCacheInterface;
 use App\Air\ValueDataConverter\ValueDataConverter;
 use Caldera\LuftModel\Model\Value;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\Persistence\ManagerRegistry;
 
 class PostgisPersister extends AbstractPersister
@@ -29,11 +30,17 @@ class PostgisPersister extends AbstractPersister
 
                 $data = ValueDataConverter::convert($value, $station);
 
-                $em->persist($data);
+                if ($data) {
+                    $em->persist($data);
+                }
             }
         }
 
-        $em->flush();
+        try {
+            $em->flush();
+        } catch (UniqueConstraintViolationException) {
+            // Duplicate data point already exists, skip silently
+        }
 
         return $this;
     }

--- a/src/Entity/Data.php
+++ b/src/Entity/Data.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Attribute\Ignore;
 
 #[ORM\Table(name: 'data')]
+#[ORM\UniqueConstraint(name: 'unique_station_pollutant_datetime', columns: ['station_id', 'pollutant', 'date_time'])]
 #[ORM\Entity(repositoryClass: \App\Repository\DataRepository::class)]
 class Data
 {


### PR DESCRIPTION
## Summary
- Add unique constraint on `(station_id, pollutant, date_time)` to `data` table
- Handle `UniqueConstraintViolationException` in PostgisPersister
- Also adds null check for `ValueDataConverter::convert()` return value

## Context
Without a unique constraint, repeated imports (e.g. retries, overlapping fetches) could insert duplicate rows for the same measurement. The constraint ensures data integrity at the database level.

## Test plan
- [ ] Generate and run Doctrine migration: `php bin/console doctrine:migrations:diff` then `php bin/console doctrine:migrations:migrate`
- [ ] Verify importing the same data twice does not cause errors
- [ ] Verify normal import flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)