### PR TITLE
Add error handling to AdhocDataRetriever

### DIFF
--- a/src/Air/DataRetriever/AdhocDataRetriever.php
+++ b/src/Air/DataRetriever/AdhocDataRetriever.php
@@ -35,11 +35,14 @@ class AdhocDataRetriever implements DataRetrieverInterface
 
     protected function retrieveTemperatureForCoord(CoordInterface $coord): ?Data
     {
-        $jsonData = $this->owmSourceFetcher->queryTemperature($coord);
+        try {
+            $jsonData = $this->owmSourceFetcher->queryTemperature($coord);
+            $value = $this->owmJsonParser->parseTemperature($jsonData);
 
-        $value = $this->owmJsonParser->parseTemperature($jsonData);
-
-        $station = new Station($coord->getLatitude(), $coord->getLongitude());
-        return ValueDataConverter::convert($value, $station);
+            $station = new Station($coord->getLatitude(), $coord->getLongitude());
+            return ValueDataConverter::convert($value, $station);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap OpenWeatherMap API call in try/catch
- Return null instead of crashing when the external API is unavailable

## Problem
The `AdhocDataRetriever` calls the OpenWeatherMap API on every page load for coordinate-based queries. If the API is down, rate-limited, or returns invalid JSON, the entire page crashes with an unhandled exception.

## Test plan
- [ ] Verify page still loads when OWM API key is invalid or API is unreachable
- [ ] Verify temperature data still shows when API works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)