### PR TITLE
Increase StationCache TTL from 3 seconds to 5 minutes

### DIFF
--- a/src/Air/StationCache/StationCache.php
+++ b/src/Air/StationCache/StationCache.php
@@ -9,7 +9,7 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 class StationCache implements StationCacheInterface
 {
-    final public const int TTL = 3;
+    final public const int TTL = 300;
     final public const string CACHE_KEY = 'luft_stations';
     protected array $list = [];
     protected AbstractAdapter $cache;


### PR DESCRIPTION
## Summary
- Increase Redis station cache TTL from 3 seconds to 300 seconds (5 minutes)

## Context
Station metadata (codes, coordinates, providers) changes very rarely. A 3-second TTL means the station list is reloaded from the database on nearly every request, defeating the purpose of caching. A 5-minute TTL significantly reduces database load while still picking up new stations within a reasonable timeframe.

## Test plan
- [ ] Verify station lookups still work after the change
- [ ] Monitor Redis cache hit rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)