### PR TITLE
Add null-safe operator to Data::getProvider()

### DIFF
--- a/src/Entity/Data.php
+++ b/src/Entity/Data.php
@@ -107,7 +107,7 @@ class Data
 
     public function getProvider(): ?string
     {
-        return $this->station->getProvider();
+        return $this->station?->getProvider();
     }
 
     public function isIndexable(): bool


### PR DESCRIPTION
## Summary
- Use nullsafe operator (`?->`) in `Data::getProvider()` to prevent TypeError

## Problem
`Data::station` is typed as `?Station` (nullable), but `getProvider()` called `$this->station->getProvider()` directly. This crashes when station is null, e.g. for adhoc Data objects created by `AdhocDataRetriever`.

## Test plan
- [ ] Verify pages rendering Data objects without stations don't crash
- [ ] Verify station detail pages still show the provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)