### PR TITLE
Remove var_dump() debug output from limitsAction

### DIFF
--- a/src/Controller/StationController.php
+++ b/src/Controller/StationController.php
@@ -42,10 +42,6 @@ class StationController extends AbstractController
 
     public function limitsAction(#[MapEntity(expr: 'repository.findOneByStationCode(stationCode)')] Station $station, LimitAnalysisInterface $limitAnalysis): Response
     {
-        if (!$station) {
-            throw $this->createNotFoundException();
-        }
-
         $limitAnalysis
             ->setStation($station)
             ->setFromDateTime(Carbon::now()->startOfMonth())
@@ -53,7 +49,6 @@ class StationController extends AbstractController
 
         $exceedance = $limitAnalysis->analyze();
 
-        var_dump($exceedance);
         return $this->render('Station/limits.html.twig', [
             'exceedanceJson' => json_encode($exceedance, JSON_THROW_ON_ERROR),
         ]);


### PR DESCRIPTION
## Summary
- Remove `var_dump($exceedance)` left in production code
- Remove redundant null check on `$station` (MapEntity already throws 404)

## Problem
The limits page (`/station/{stationCode}/limits`) outputs raw `var_dump` data before the actual HTML response, breaking the page layout and exposing internal data structures.

## Test plan
- [ ] Visit a station limits page and verify clean HTML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)