### PR TITLE
Fix coordinate order in Station constructor

### DIFF
--- a/src/Entity/Station.php
+++ b/src/Entity/Station.php
@@ -86,7 +86,7 @@ class Station extends Coordinate
     {
         $this->datas = new ArrayCollection();
 
-        $this->coord = sprintf('POINT(%f %f)', $latitude, $longitude);
+        $this->coord = sprintf('POINT(%f %f)', $longitude, $latitude);
 
         parent::__construct($latitude, $longitude);
     }


### PR DESCRIPTION
## Summary
- Fix POINT coordinate order from `(latitude, longitude)` to `(longitude, latitude)`

## Problem
PostGIS expects `POINT(longitude latitude)` ([x y] convention), but the Station constructor wrote `POINT(latitude longitude)`. The `prePersist()` lifecycle callback had the correct order, so persisted stations were fine — but adhoc Station objects (created in `AdhocDataRetriever` for real-time OWM data) were never persisted, so their `coord` field had swapped coordinates.

## Test plan
- [ ] Verify distance calculations for adhoc temperature data are correct
- [ ] Verify existing persisted stations are unaffected (prePersist still applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)