### PR TITLE
Guard against empty request body in API deserialization

### DIFF
--- a/src/Controller/Api/AbstractApiController.php
+++ b/src/Controller/Api/AbstractApiController.php
@@ -5,7 +5,9 @@ namespace App\Controller\Api;
 use App\Air\Serializer\LuftSerializerInterface;
 use App\Controller\AbstractController;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractApiController extends AbstractController
 {
@@ -31,6 +33,10 @@ abstract class AbstractApiController extends AbstractController
     protected function deserializeRequestBodyToArray(Request $request, string $expectedFqcn): array
     {
         $body = $request->getContent();
+
+        if ('' === $body) {
+            throw new \InvalidArgumentException('Request body is empty');
+        }
 
         if ('[' === $body[0]) {
             $type = sprintf('%s[]', $expectedFqcn);


### PR DESCRIPTION
## Summary
- Add empty body check before accessing `$body[0]` in `deserializeRequestBodyToArray()`

## Problem
Sending a PUT/POST request with an empty body to any value/station/city API endpoint crashes with `Uninitialized string offset 0` because the code accesses `$body[0]` without checking if the string is empty.

## Test plan
- [ ] Send empty POST to `/api/value` and verify a clear error instead of a crash
- [ ] Verify normal JSON payloads still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)