### PR TITLE
Replace Reflection in AbstractPollutionLevel::getPollutionIdentifier()

### DIFF
--- a/src/Air/AirQuality/PollutionLevel/AbstractPollutionLevel.php
+++ b/src/Air/AirQuality/PollutionLevel/AbstractPollutionLevel.php
@@ -15,9 +15,7 @@ abstract class AbstractPollutionLevel implements PollutionLevelInterface
     #[\Override]
     public function getPollutionIdentifier(): string
     {
-        $reflection = new \ReflectionClass($this);
-
-        $className = $reflection->getShortName();
+        $className = substr(strrchr(static::class, '\\'), 1);
 
         return strtolower(substr($className, 0, -5));
     }


### PR DESCRIPTION
## Summary
- Replace `ReflectionClass` with `static::class` and `strrchr()` to derive the short class name

## Context
Same pattern as the `ValueDataConverter` fix (PR #459) — Reflection was used only to get the short class name, which is easily derived from the FQCN string.

## Test plan
- [ ] Verify pollution level identifiers still resolve correctly (pm10, no2, o3, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)