### PR TITLE
Add route for /api/doc.json endpoint

### DIFF
--- a/config/routing/2_api.xml
+++ b/config/routing/2_api.xml
@@ -8,6 +8,10 @@
         <default key="_controller">nelmio_api_doc.controller.swagger_ui</default>
     </route>
 
+    <route id="app.swagger_json" path="/api/doc.json" methods="GET">
+        <default key="_controller">nelmio_api_doc.controller.swagger</default>
+    </route>
+
     <route id="api_station_station" path="/api/station/{stationCode}" methods="GET">
         <default key="_controller">App\Controller\Api\StationApiController::stationAction</default>
         <requirement key="stationCode">^([A-Z]{4,6})([0-9]{0,8})$</requirement>


### PR DESCRIPTION
## Summary
- Adds a GET route `/api/doc.json` mapped to `nelmio_api_doc.controller.swagger`, exposing the raw OpenAPI/Swagger JSON specification
- The Swagger UI at `/api/doc` was already configured, but the JSON endpoint was missing

## Test plan
- [ ] Verify `php bin/console debug:router | grep swagger` shows both `app.swagger_ui` and `app.swagger_json`
- [ ] Access `/api/doc.json` and confirm it returns the OpenAPI JSON spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)