### PR TITLE
Fix ID generation for Doctrine ORM 3 on PostgreSQL

### DIFF
--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -13,7 +13,8 @@ class City implements \Stringable
 {
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\SequenceGenerator(sequenceName: 'city_id_seq', allocationSize: 1)]
     #[Ignore]
     protected ?int $id = null;
 

--- a/src/Entity/Data.php
+++ b/src/Entity/Data.php
@@ -12,7 +12,8 @@ class Data
 {
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\SequenceGenerator(sequenceName: 'data_id_seq', allocationSize: 1)]
     #[Ignore]
     protected ?int $id = null;
 

--- a/src/Entity/Network.php
+++ b/src/Entity/Network.php
@@ -11,7 +11,8 @@ class Network
 {
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\SequenceGenerator(sequenceName: 'network_id_seq', allocationSize: 1)]
     protected ?int $id = null;
 
     #[ORM\Column(type: 'string', nullable: true)]

--- a/src/Entity/Station.php
+++ b/src/Entity/Station.php
@@ -20,7 +20,8 @@ class Station extends Coordinate
 {
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
-    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\GeneratedValue(strategy: 'SEQUENCE')]
+    #[ORM\SequenceGenerator(sequenceName: 'station_id_seq', allocationSize: 1)]
     #[Ignore]
     protected ?int $id = null;
 


### PR DESCRIPTION
## Summary
- Doctrine ORM 3 changed `AUTO` strategy from `SEQUENCE` to `IDENTITY` for PostgreSQL
- Existing database uses sequences (`data_id_seq`, `station_id_seq`, etc.)
- Explicitly set `SEQUENCE` strategy with correct sequence names on all 4 entities
- Fixes: `null value in column "id" violates not-null constraint` when inserting data via API

## Test plan
- [ ] `luft:fetch` command successfully persists new data values
- [ ] New stations and cities can be created via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)