### PR TITLE
Fix Sonata and Twig deprecation warnings

### DIFF
--- a/config/packages/sonata_block.yaml
+++ b/config/packages/sonata_block.yaml
@@ -1,2 +1,1 @@
-sonata_block:
-    http_cache: false
+sonata_block: ~

--- a/templates/Includes/breadcrumbs.html.twig
+++ b/templates/Includes/breadcrumbs.html.twig
@@ -1,30 +1,28 @@
 {% if wo_breadcrumbs()|length %}
-    {%- apply spaceless -%}
-        <div class="container mt-3">
-            <nav aria-label="breadcrumb">
-                <ol id="{{ listId }}" class="{{ listClass }}" itemscope itemtype="http://schema.org/BreadcrumbList">
-                    {% for b in breadcrumbs %}
-                        <li{% if itemClass is defined and itemClass|length %} class="{{ itemClass }}"{% endif %}
-                                itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+    <div class="container mt-3">
+        <nav aria-label="breadcrumb">
+            <ol id="{{ listId }}" class="{{ listClass }}" itemscope itemtype="http://schema.org/BreadcrumbList">
+                {% for b in breadcrumbs %}
+                    <li{% if itemClass is defined and itemClass|length %} class="{{ itemClass }}"{% endif %}
+                            itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                        {% if b.url and not loop.last %}
+                        <a href="{{ b.url }}"
+                           itemprop="item"{% if linkRel is defined and linkRel|length %} rel="{{ linkRel }}"{% endif %}>
+                            {% endif %}
+                            <span itemprop="name">{% if b.translate is defined and b.translate == true %}{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}{% else %}{{- b.text -}}{% endif %}</span>
                             {% if b.url and not loop.last %}
-                            <a href="{{ b.url }}"
-                               itemprop="item"{% if linkRel is defined and linkRel|length %} rel="{{ linkRel }}"{% endif %}>
-                                {% endif %}
-                                <span itemprop="name">{% if b.translate is defined and b.translate == true %}{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}{% else %}{{- b.text -}}{% endif %}</span>
-                                {% if b.url and not loop.last %}
-                            </a>
-                        {% elseif b.url %}
-                            <meta itemprop="item" content="{{ b.url }}"/>
-                            {% endif %}
-                            <meta itemprop="position" content="{{ loop.index }}"/>
+                        </a>
+                    {% elseif b.url %}
+                        <meta itemprop="item" content="{{ b.url }}"/>
+                        {% endif %}
+                        <meta itemprop="position" content="{{ loop.index }}"/>
 
-                            {% if separator is not null and not loop.last %}
-                                <span class="{{ separatorClass }}">{{ separator }}</span>
-                            {% endif %}
-                        </li>
-                    {% endfor %}
-                </ol>
-            </nav>
-        </div>
-    {% endapply %}
+                        {% if separator is not null and not loop.last %}
+                            <span class="{{ separatorClass }}">{{ separator }}</span>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ol>
+        </nav>
+    </div>
 {% endif %}


### PR DESCRIPTION
## Summary
- Remove deprecated `http_cache` option from `sonata_block` config (Sonata 5.0)
- Remove deprecated `spaceless` filter from breadcrumbs template (Twig 3.12)

Note: The XML dependency-injection deprecations come from third-party bundles
(internal XML service configs) and cannot be fixed on our side.

## Test plan
- [ ] `cache:clear` runs without deprecation warnings for these two items
- [ ] Breadcrumbs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)