### PR TITLE
Remove obsolete data_view materialized view reference

### DIFF
--- a/src/Command/LuftRefreshCommand.php
+++ b/src/Command/LuftRefreshCommand.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 #[AsCommand(
     name: 'luft:refresh',
-    description: 'Refresh all materialized views (data_view, silvester_data, current_data)',
+    description: 'Refresh all materialized views (current_data, silvester_data)',
 )]
 class LuftRefreshCommand extends Command
 {

--- a/src/Repository/DataRepository.php
+++ b/src/Repository/DataRepository.php
@@ -84,9 +84,8 @@ LIMIT 10';
     {
         $connection = $this->getEntityManager()->getConnection();
 
-        $connection->executeStatement('REFRESH MATERIALIZED VIEW data_view');
-        $connection->executeStatement('REFRESH MATERIALIZED VIEW silvester_data');
         $connection->executeStatement('REFRESH MATERIALIZED VIEW current_data');
+        $connection->executeStatement('REFRESH MATERIALIZED VIEW silvester_data');
     }
 
     private function createDataStationResultSetMapping(string $dataIdColumn): ResultSetMapping


### PR DESCRIPTION
## Summary
- Remove redundant `REFRESH MATERIALIZED VIEW data_view` — this view is never queried in code
- Unify on `current_data` as the single materialized view name for current measurement data
- Update command description to reflect the two remaining views

**Note:** The `data_view` materialized view in the database should be renamed:
```sql
ALTER MATERIALIZED VIEW data_view RENAME TO current_data;
```

## Test plan
- [ ] CI passes (PHPStan + PHPUnit)
- [ ] Rename `data_view` to `current_data` in PostgreSQL before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)