### PR TITLE
Handle Nominatim QuotaExceeded gracefully

### DIFF
--- a/assets/js/modules/Search.js
+++ b/assets/js/modules/Search.js
@@ -124,16 +124,29 @@ export default class Search {
                         sourceId: 'remote',
                         getItems() {
                             return fetch(Routing.generate('search') + '?query=' + encodeURIComponent(query))
-                                .then(response => response.json())
-                                .then(data => data.slice(0, 5))
+                                .then(response => {
+                                    if (response.status === 429) {
+                                        return response.json().then(data => [{ _error: data.error }]);
+                                    }
+                                    return response.json();
+                                })
+                                .then(data => {
+                                    if (data.error) return [];
+                                    return data.slice(0, 5);
+                                })
                                 .catch(() => []);
                         },
                         templates: {
                             header({ items, html }) {
+                                const errorItem = items.find(item => item._error);
+                                if (errorItem) {
+                                    return html`<div class="aa-SourceHeader aa-SourceHeader--error"><i class="fa fa-exclamation-triangle"></i> ${errorItem._error}</div>`;
+                                }
                                 if (items.length === 0) return null;
                                 return html`<div class="aa-SourceHeader"><i class="fa fa-map-marker"></i> Orte</div>`;
                             },
                             item({ item, html }) {
+                                if (item._error) return html`<div style="display:none"></div>`;
                                 const url = actionUri + '?latitude=' + item.value.latitude + '&longitude=' + item.value.longitude;
                                 return html`
                                     <a href="${url}" class="aa-ItemLink">

--- a/assets/scss/typeahead.scss
+++ b/assets/scss/typeahead.scss
@@ -120,6 +120,13 @@
   .fa {
     font-size: 0.625rem;
   }
+
+  &--error {
+    color: var(--bs-danger);
+    text-transform: none;
+    font-weight: normal;
+    font-size: 0.8125rem;
+  }
 }
 
 .aa-List {

--- a/config/packages/bazinga_geocoder.yaml
+++ b/config/packages/bazinga_geocoder.yaml
@@ -7,5 +7,5 @@ bazinga_geocoder:
         nominatim:
             factory: Bazinga\GeocoderBundle\ProviderFactory\NominatimFactory
             cache: 'app.geocoding_cache'
-            cache_lifetime: 3600
+            cache_lifetime: 86400
             cache_precision: 4

--- a/src/Air/Geocoding/RequestConverter/RequestConverter.php
+++ b/src/Air/Geocoding/RequestConverter/RequestConverter.php
@@ -7,6 +7,7 @@ use App\Entity\Zip;
 use App\Geo\Coordinate\Coordinate;
 use App\Geo\Coordinate\CoordinateInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Geocoder\Exception\QuotaExceeded;
 use Geocoder\Provider\Nominatim\Model\NominatimAddress;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -24,15 +25,19 @@ class RequestConverter implements RequestConverterInterface
         $query = $request->query->get('query');
         $zipCode = $request->query->get('zip');
 
-        if (($query && preg_match('/^([0-9]{5,5})$/', $query)) || $zipCode) {
-            $cityList = $this->geocoder->queryZip($query ?? $zipCode);
+        try {
+            if (($query && preg_match('/^([0-9]{5,5})$/', $query)) || $zipCode) {
+                $cityList = $this->geocoder->queryZip($query ?? $zipCode);
 
-            if (count($cityList) > 0) {
-                /** @var NominatimAddress $firstResult */
-                $firstResult = $cityList->first();
+                if (count($cityList) > 0) {
+                    /** @var NominatimAddress $firstResult */
+                    $firstResult = $cityList->first();
 
-                return new Coordinate($firstResult->getCoordinates()->getLatitude(), $firstResult->getCoordinates()->getLongitude());
+                    return new Coordinate($firstResult->getCoordinates()->getLatitude(), $firstResult->getCoordinates()->getLongitude());
+                }
             }
+        } catch (QuotaExceeded) {
+            return null;
         }
 
         if ($latitude && $longitude) {
@@ -44,16 +49,20 @@ class RequestConverter implements RequestConverterInterface
             return $coord;
         }
 
-        if ($query) {
-            $result = $this->geocoder->query($query);
+        try {
+            if ($query) {
+                $result = $this->geocoder->query($query);
 
-            $firstResult = array_pop($result);
+                $firstResult = array_pop($result);
 
-            if ($firstResult) {
-                $coord = new Coordinate($firstResult['value']['latitude'], $firstResult['value']['longitude']);
+                if ($firstResult) {
+                    $coord = new Coordinate($firstResult['value']['latitude'], $firstResult['value']['longitude']);
 
-                return $coord;
+                    return $coord;
+                }
             }
+        } catch (QuotaExceeded) {
+            return null;
         }
 
         return null;

--- a/src/Controller/TypeaheadController.php
+++ b/src/Controller/TypeaheadController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Air\Geocoding\Geocoder\GeocoderInterface;
 use App\Entity\City;
 use App\Entity\Station;
+use Geocoder\Exception\QuotaExceeded;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -59,7 +60,11 @@ class TypeaheadController extends AbstractController
 
     public function searchAction(Request $request, GeocoderInterface $geocoder): Response
     {
-        $result = $geocoder->query($request->query->get('query'));
+        try {
+            $result = $geocoder->query($request->query->get('query'));
+        } catch (QuotaExceeded) {
+            return new JsonResponse(['error' => 'Die Suche ist momentan überlastet. Bitte versuche es in einigen Sekunden erneut.'], Response::HTTP_TOO_MANY_REQUESTS);
+        }
 
         return new JsonResponse($result);
     }


### PR DESCRIPTION
## Summary
- Catch `QuotaExceeded` in `TypeaheadController` and return HTTP 429 with German error message instead of 500
- Catch `QuotaExceeded` in `RequestConverter` and fall back to `null` silently
- Increase geocoding cache lifetime from 1h to 24h to reduce Nominatim API calls
- Display inline error message in autocomplete dropdown when rate-limited

## Test plan
- [ ] Search with Nominatim available: results appear as before
- [ ] Search when rate-limited: red error message appears in dropdown instead of empty/broken state
- [ ] ZIP code and query lookups via `RequestConverter` degrade gracefully on quota exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)