### PR TITLE
[Kritisch] Web-Profiler aus Produktion entfernen

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -5,7 +5,7 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
-    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['prod' => true, 'dev' => true, 'test' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],

--- a/config/routing/dev/web_profiler.yaml
+++ b/config/routing/dev/web_profiler.yaml
@@ -1,7 +1,8 @@
-web_profiler_wdt:
-    resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
-    prefix: /_wdt
+when@dev:
+    web_profiler_wdt:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
+        prefix: /_wdt
 
-web_profiler_profiler:
-    resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
-    prefix: /_profiler
+    web_profiler_profiler:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
+        prefix: /_profiler


### PR DESCRIPTION
Behebt #521.

## Problem
Der Symfony-Web-Profiler war in der **Produktionsumgebung** erreichbar:
1. `config/bundles.php` aktivierte `WebProfilerBundle` für `prod`.
2. `config/routing/dev/web_profiler.yaml` registrierte `/_profiler` und `/_wdt` **ohne** `when@dev:`-Schutz und wurde über den Verzeichnis-Import in jeder Umgebung geladen.

Bestätigt via `bin/console debug:router --env=prod` — sichtbar waren u. a. `/_profiler/open` (liest Serverdateien), `/_profiler/phpinfo` und `/_wdt/{token}`.

## Änderung
- `config/bundles.php`: `WebProfilerBundle` nur noch für `dev`/`test`.
- `config/routing/dev/web_profiler.yaml`: Inhalt in `when@dev:` gekapselt (identisch zum Symfony-Standardmuster).

> Hinweis: Die `dev/`-Routing-Datei ist die tatsächlich geladene Profiler-Routendefinition (die `when@dev`-geschützte `config/routes/web_profiler.yaml` wird im aktuellen Setup gar nicht importiert). Deshalb wurde die aktive Datei gekapselt statt gelöscht — sonst wäre der Profiler auch in `dev` verschwunden.

## Verifikation
```
debug:router --env=prod  → keine _profiler/_wdt-Routen mehr
debug:router --env=dev   → Profiler-Routen unverändert vorhanden
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)