### PR TITLE
[Kritisch] Schreibende API-Endpunkte mit Bearer-Token absichern

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,12 @@ GRAPH_CACHE_DIRECTORY='/var/www/luft/public/img/graph_cache'
 
 OPENWEATHERMAP_APPID='asdf'
 
+# Gemeinsames Bearer-Token zum Schutz der schreibenden API-Endpunkte
+# (POST/PUT/PATCH/DELETE unter /api). Leer = kein Schutz (Bestandsverhalten).
+# In Produktion ein starkes Zufallstoken setzen (z. B. `openssl rand -hex 32`)
+# und dasselbe Token in den Providern / im luft-api-bundle hinterlegen.
+LUFT_API_TOKEN=
+
 REDIS_HOST="localhost"
 
 DATABASE_HOST=127.0.0.1

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,6 +16,7 @@ services:
         bind:
             $graphCacheDirectory: '%env(GRAPH_CACHE_DIRECTORY)%'
             $redisHost: 'redis://%env(REDIS_HOST)%'
+            $apiToken: '%env(LUFT_API_TOKEN)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/EventSubscriber/ApiTokenSubscriber.php
+++ b/src/EventSubscriber/ApiTokenSubscriber.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Schützt die schreibenden API-Endpunkte (POST/PUT/PATCH/DELETE unterhalb von
+ * /api) mit einem gemeinsamen Bearer-Token aus der Umgebungsvariable
+ * LUFT_API_TOKEN.
+ *
+ * Opt-in: Ist LUFT_API_TOKEN leer/nicht gesetzt, bleibt das Verhalten
+ * unverändert (kein Schutz). Dadurch erhalten die Provider nicht unvermittelt
+ * 401, bevor sie das Token mitsenden. Sobald das Token gesetzt ist, werden
+ * schreibende Requests ohne gültigen Header mit 401 abgewiesen. Lesende
+ * Requests (GET, u. a. /api/doc) bleiben immer öffentlich.
+ */
+class ApiTokenSubscriber implements EventSubscriberInterface
+{
+    private const MUTATING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+    public function __construct(private readonly string $apiToken)
+    {
+    }
+
+    #[\Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onRequest', 16],
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if ('' === $this->apiToken) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$this->requiresAuthentication($request)) {
+            return;
+        }
+
+        $providedToken = $this->extractBearerToken($request);
+
+        if (null === $providedToken || !hash_equals($this->apiToken, $providedToken)) {
+            throw new UnauthorizedHttpException('Bearer', 'Invalid or missing API token.');
+        }
+    }
+
+    private function requiresAuthentication(Request $request): bool
+    {
+        return in_array($request->getMethod(), self::MUTATING_METHODS, true)
+            && str_starts_with($request->getPathInfo(), '/api');
+    }
+
+    private function extractBearerToken(Request $request): ?string
+    {
+        $authorizationHeader = $request->headers->get('Authorization', '');
+
+        if (!str_starts_with($authorizationHeader, 'Bearer ')) {
+            return null;
+        }
+
+        $token = substr($authorizationHeader, 7);
+
+        return '' !== $token ? $token : null;
+    }
+}

--- a/tests/EventSubscriber/ApiTokenSubscriberTest.php
+++ b/tests/EventSubscriber/ApiTokenSubscriberTest.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\EventSubscriber;
+
+use App\EventSubscriber\ApiTokenSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class ApiTokenSubscriberTest extends TestCase
+{
+    private const TOKEN = 's3cr3t-token';
+
+    public function testWriteRequestIsAllowedWhenTokenIsNotConfigured(): void
+    {
+        $subscriber = new ApiTokenSubscriber('');
+        $event = $this->createRequestEvent('PUT', '/api/value');
+
+        $subscriber->onRequest($event);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testWriteRequestWithoutAuthorizationHeaderIsRejected(): void
+    {
+        $subscriber = new ApiTokenSubscriber(self::TOKEN);
+        $event = $this->createRequestEvent('PUT', '/api/value');
+
+        $this->expectException(UnauthorizedHttpException::class);
+
+        $subscriber->onRequest($event);
+    }
+
+    public function testWriteRequestWithWrongTokenIsRejected(): void
+    {
+        $subscriber = new ApiTokenSubscriber(self::TOKEN);
+        $event = $this->createRequestEvent('PUT', '/api/value', 'Bearer wrong-token');
+
+        $this->expectException(UnauthorizedHttpException::class);
+
+        $subscriber->onRequest($event);
+    }
+
+    public function testWriteRequestWithCorrectTokenIsAllowed(): void
+    {
+        $subscriber = new ApiTokenSubscriber(self::TOKEN);
+        $event = $this->createRequestEvent('PUT', '/api/value', 'Bearer '.self::TOKEN);
+
+        $subscriber->onRequest($event);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testReadRequestStaysPublicEvenWithTokenConfigured(): void
+    {
+        $subscriber = new ApiTokenSubscriber(self::TOKEN);
+        $event = $this->createRequestEvent('GET', '/api/station');
+
+        $subscriber->onRequest($event);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testNonApiWriteRequestIsNotGuarded(): void
+    {
+        $subscriber = new ApiTokenSubscriber(self::TOKEN);
+        $event = $this->createRequestEvent('POST', '/search/query');
+
+        $subscriber->onRequest($event);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testSubRequestIsIgnored(): void
+    {
+        $subscriber = new ApiTokenSubscriber(self::TOKEN);
+        $event = $this->createRequestEvent('PUT', '/api/value', null, HttpKernelInterface::SUB_REQUEST);
+
+        $subscriber->onRequest($event);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    private function createRequestEvent(
+        string $method,
+        string $path,
+        ?string $authorizationHeader = null,
+        int $requestType = HttpKernelInterface::MAIN_REQUEST,
+    ): RequestEvent {
+        $request = Request::create($path, $method);
+
+        if (null !== $authorizationHeader) {
+            $request->headers->set('Authorization', $authorizationHeader);
+        }
+
+        return new RequestEvent($this->createStub(HttpKernelInterface::class), $request, $requestType);
+    }
+}


### PR DESCRIPTION
Adressiert #522.

## Problem
`PUT/POST /api/station`, `/api/city` und `PUT /api/value` schreiben ohne jede Authentifizierung in die DB (keine `security.yaml`-Firewall, kein `#[IsGranted]`).

## Lösung — leichtgewichtiger, opt-in Bearer-Token
Neuer `ApiTokenSubscriber` (`kernel.request`, Priorität 16):
- Prüft bei **mutierenden** Methoden (`POST/PUT/PATCH/DELETE`) unterhalb `/api` den Header `Authorization: Bearer <token>` gegen `env(LUFT_API_TOKEN)` — konstantzeit-Vergleich via `hash_equals`.
- **Lesende** Requests (GET, inkl. `/api/doc`) bleiben öffentlich.
- **Opt-in:** Ist `LUFT_API_TOKEN` leer (Default in `.env`), bleibt das Verhalten unverändert. So erhalten die laufenden Provider **nicht** unvermittelt 401, bevor sie das Token mitsenden.

## Aktivierung (nach dem Merge)
1. In luft-app ein starkes Token setzen: `LUFT_API_TOKEN=$(openssl rand -hex 32)` (über echte Env-Var/Secrets, nicht in die getrackte `.env`).
2. Dasselbe Token in den Providern hinterlegen — sobald das `luft-api-bundle` den Header sendet (separater PR in luft-api-bundle, folgt).

## Tests
`tests/EventSubscriber/ApiTokenSubscriberTest.php` — 7 Fälle: kein/leeres/falsches/korrektes Token, Read-Pfad bleibt offen, Nicht-`/api`-POST ungeschützt, Sub-Request ignoriert. Gesamte Unit-Suite grün (128 Tests), `lint:container` OK.

## Hinweis
Dies ist die einfachste, nicht-brechende Variante (gewählt nach Rücksprache). Ein vollwertiges `security-bundle`-Setup wäre die Alternative für mehrere Tokens/Rollen.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)