### PR TITLE
[Hoch] EntityMerger: #[Ignore] wirksam machen und falsy Werte korrekt mergen

### DIFF
--- a/src/Air/Util/EntityMerger/EntityMerger.php
+++ b/src/Air/Util/EntityMerger/EntityMerger.php
@@ -20,7 +20,7 @@ class EntityMerger implements EntityMergerInterface
                 try {
                     $newValue = $source->$getMethodName();
 
-                    if ($newValue) {
+                    if (null !== $newValue) {
                         $destination->$setMethodName($newValue);
                     }
                 } catch (\TypeError) {
@@ -38,15 +38,9 @@ class EntityMerger implements EntityMergerInterface
 
     protected function isPropertyExposed(\ReflectionProperty $reflectionProperty): bool
     {
-        $propertyAttributes = $reflectionProperty->getAttributes(Ignore::class);
-
-        foreach ($propertyAttributes as $propertyAttribute) {
-            if ($propertyAttribute instanceof Ignore) {
-                return false;
-            }
-        }
-
-        return true;
+        // getAttributes() liefert ReflectionAttribute-Objekte (nie Ignore-Instanzen);
+        // gefiltert auf Ignore::class bedeutet ein nicht-leeres Array also: Property ist mit #[Ignore] markiert.
+        return [] === $reflectionProperty->getAttributes(Ignore::class);
     }
 
     protected function generateSetMethodName(\ReflectionProperty $reflectionProperty): string

--- a/tests/Air/Util/EntityMerger/EntityMergerTest.php
+++ b/tests/Air/Util/EntityMerger/EntityMergerTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Air\Util\EntityMerger;
+
+use App\Air\Util\EntityMerger\EntityMerger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Attribute\Ignore;
+
+class EntityMergerTest extends TestCase
+{
+    private EntityMerger $entityMerger;
+
+    protected function setUp(): void
+    {
+        $this->entityMerger = new EntityMerger();
+    }
+
+    public function testNonNullValuesAreCopied(): void
+    {
+        $source = (new EntityMergerFixture())->setName('new')->setCount(42);
+        $destination = (new EntityMergerFixture())->setName('old')->setCount(1);
+
+        $this->entityMerger->merge($source, $destination);
+
+        $this->assertSame('new', $destination->getName());
+        $this->assertSame(42, $destination->getCount());
+    }
+
+    public function testNullValuesAreNotCopied(): void
+    {
+        $source = (new EntityMergerFixture())->setName(null);
+        $destination = (new EntityMergerFixture())->setName('keep');
+
+        $this->entityMerger->merge($source, $destination);
+
+        $this->assertSame('keep', $destination->getName());
+    }
+
+    public function testFalsyButNonNullValuesAreCopied(): void
+    {
+        // Regression: vorher verwarf `if ($newValue)` die Werte 0 / '' / false.
+        $source = (new EntityMergerFixture())->setCount(0)->setName('');
+        $destination = (new EntityMergerFixture())->setCount(99)->setName('old');
+
+        $this->entityMerger->merge($source, $destination);
+
+        $this->assertSame(0, $destination->getCount());
+        $this->assertSame('', $destination->getName());
+    }
+
+    public function testIgnoredPropertiesAreNotCopied(): void
+    {
+        // Regression: der frühere instanceof-Check war immer false, #[Ignore] also wirkungslos.
+        $source = (new EntityMergerFixture())->setSecret('injected');
+        $destination = (new EntityMergerFixture())->setSecret('protected');
+
+        $this->entityMerger->merge($source, $destination);
+
+        $this->assertSame('protected', $destination->getSecret());
+    }
+}
+
+class EntityMergerFixture
+{
+    private ?string $name = null;
+
+    private ?int $count = null;
+
+    #[Ignore]
+    private ?string $secret = null;
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getCount(): ?int
+    {
+        return $this->count;
+    }
+
+    public function setCount(?int $count): self
+    {
+        $this->count = $count;
+
+        return $this;
+    }
+
+    public function getSecret(): ?string
+    {
+        return $this->secret;
+    }
+
+    public function setSecret(?string $secret): self
+    {
+        $this->secret = $secret;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Behebt #523 (die beiden Korrektheits-Bugs; die breitere Mass-Assignment-Frage siehe unten).

## Zwei Bugs in `EntityMerger::merge()`

**1. `#[Ignore]` war wirkungslos**
```php
foreach ($reflectionProperty->getAttributes(Ignore::class) as $attr) {
    if ($attr instanceof Ignore) { return false; }   // immer false
}
```
`getAttributes()` liefert `ReflectionAttribute`-Wrapper, nie `Ignore`-Instanzen — der Check schlug nie an, jede Property galt als exponiert. Neu: Property ist exponiert, wenn sie **kein** `#[Ignore]` trägt (`[] === getAttributes(Ignore::class)`).

**2. Falsy-Werte wurden verworfen**
```php
if ($newValue) { ... }   // verwirft 0, '', false
```
Damit ließ sich z. B. `altitude = 0` (Meereshöhe) oder das Leeren eines Feldes nicht setzen. Neu: `null !== $newValue` — nur nicht gesetzte (null-)Felder werden übersprungen, was die korrekte Partial-Update-Semantik ist.

## Tests
`tests/Air/Util/EntityMerger/EntityMergerTest.php` — 4 Fälle: non-null kopieren, null überspringen, falsy (0/'') kopieren, `#[Ignore]` respektieren. Gesamte Unit-Suite grün (125 Tests).

## Verbleibend (nicht in diesem PR)
Die eigentliche Mass-Assignment-Lücke (`stationCode`, `provider` etc. sind **nicht** `#[Ignore]`, weil sie beim Anlegen via PUT deserialisiert werden müssen) lässt sich nicht über `#[Ignore]` lösen, ohne das Anlegen zu brechen. Sie wird über die API-Authentifizierung (#522, PR #530) abgedeckt; eine saubere Dauerlösung wäre eine explizite Allowlist mutierbarer Felder bzw. ein separates Update-DTO.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)