### PR TITLE
[Hoch] Sicherheits-Updates: Twig (kritisch) + Symfony-Patches

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6481,16 +6481,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.4",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "48b067768859f7b68acf41dfb857a5a4be00acdd"
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/48b067768859f7b68acf41dfb857a5a4be00acdd",
-                "reference": "48b067768859f7b68acf41dfb857a5a4be00acdd",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9df847980c436451f4f51d1284491bb4356dd989",
+                "reference": "9df847980c436451f4f51d1284491bb4356dd989",
                 "shasum": ""
             },
             "require": {
@@ -6532,7 +6532,7 @@
                 "symfony/config": "^6.4|^7.0|^8.0",
                 "symfony/console": "^6.4|^7.0|^8.0",
                 "symfony/css-selector": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4.1|^7.0.1|^8.0",
                 "symfony/dom-crawler": "^6.4|^7.0|^8.0",
                 "symfony/expression-language": "^6.4|^7.0|^8.0",
                 "symfony/finder": "^6.4|^7.0|^8.0",
@@ -6576,7 +6576,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.4"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6596,20 +6596,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T22:13:01+00:00"
+            "time": "2026-05-27T08:31:43+00:00"
         },
         {
             "name": "symfony/monolog-bridge",
-            "version": "v7.4.4",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bridge.git",
-                "reference": "9c34e8170b09f062a9a38880a3cb58ee35cb7fd4"
+                "reference": "20bb2345ac7a9dd57724b6b7ada92c6d7d67b4b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/9c34e8170b09f062a9a38880a3cb58ee35cb7fd4",
-                "reference": "9c34e8170b09f062a9a38880a3cb58ee35cb7fd4",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/20bb2345ac7a9dd57724b6b7ada92c6d7d67b4b8",
+                "reference": "20bb2345ac7a9dd57724b6b7ada92c6d7d67b4b8",
                 "shasum": ""
             },
             "require": {
@@ -6659,7 +6659,7 @@
             "description": "Provides integration for Monolog with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/monolog-bridge/tree/v7.4.4"
+                "source": "https://github.com/symfony/monolog-bridge/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -6679,7 +6679,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-07T11:35:36+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -9395,16 +9395,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.23.0",
+            "version": "v3.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9"
+                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
-                "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ae2071bffb38f04847fc0864d730c94b9cb8ab74",
+                "reference": "ae2071bffb38f04847fc0864d730c94b9cb8ab74",
                 "shasum": ""
             },
             "require": {
@@ -9414,7 +9414,8 @@
                 "symfony/polyfill-mbstring": "^1.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "^2.0",
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
                 "psr/container": "^1.0|^2.0",
                 "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
             },
@@ -9458,7 +9459,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.23.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.1"
             },
             "funding": [
                 {
@@ -9470,7 +9471,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-23T21:00:41+00:00"
+            "time": "2026-05-30T17:09:26+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Adressiert #525 (composer-Teil; npm/Rest siehe unten).

## Was wird behoben
Alle **kritischen und hohen** composer-Advisories aus #525:

| Paket | Update | CVE(s) |
|---|---|---|
| twig/twig | 3.23.0 → **3.27.1** | **CVE-2026-46633 (kritisch, PHP-Code-Injection via `{% use %}`)**, CVE-2026-46640 (hoch, RCE via `_self`), CVE-2026-24425/-47732, … |
| symfony/monolog-bridge | 7.4.4 → **7.4.12** | **CVE-2026-45077 (hoch, unauth. PHP-Object-Deserialization)** |
| symfony/http-kernel | 7.4.4 → **7.4.13** | CVE-2026-45075 (HEAD-Bypass `#[IsGranted]`) |

`composer audit` danach: **0 kritische, 0 hohe** Advisories (vorher 27 Advisories).

## Warum nicht alle Symfony-Pakete?
Ein `composer update "symfony/*"` zieht die Komponenten auf **8.1.0**. Damit meldet **PHPStan 1.12.33** flächig `unknown class Symfony\Component\HttpFoundation\Request/Response` (87 Fehler) — die Analyse bricht, CI würde rot. PHPStan ^2.0 (das 8.1 versteht) ist hier durch **`rector/rector` (verlangt phpstan ^1.12.5)** blockiert. Laufzeit ist nicht betroffen (Tests/Container-Lint grün), aber CI schon.

Deshalb bleiben die Symfony-Komponenten bewusst auf **8.0.x/7.4.x**; nur Patch-/Twig-Updates, die PHPStan unverändert grün lassen.

## Verifikation
- `composer audit` → keine kritischen/hohen Advisories mehr
- `vendor/bin/phpstan analyse` → **[OK] No errors** (unverändert)
- `bin/console lint:container` (test) → ok
- Unit-Suite → **121 Tests grün**
- Nur `composer.lock` geändert

## Verbleibend (separate Folge-Issues empfohlen)
- **Symfony 8.1 + PHPStan ^2.0 + rector-Update** als gemeinsames Vorhaben, um die restlichen **mittel/niedrig**-CVEs zu schließen (cache, http-foundation, routing, yaml, runtime, dom-crawler, web-profiler-bundle).
- **npm:** `npm audit fix` senkt 17 → 6 Schwachstellen (Rest nur via `--force`/breaking). Benötigt **Node ≥ 14** — die lokale Umgebung läuft auf **Node 12 (EOL)**, wo der Webpack-Build bereits unabhängig von diesem PR fehlschlägt (`Unexpected token '?'`). Node-Upgrade vorab nötig; daher hier nicht gebündelt.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)