### PR TITLE
Disable Web Profiler & debug routes in production (#521)

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -5,7 +5,7 @@ return [
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
-    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['prod' => true, 'dev' => true, 'test' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],

--- a/config/routing/dev/web_profiler.yaml
+++ b/config/routing/dev/web_profiler.yaml
@@ -1,7 +1,0 @@
-web_profiler_wdt:
-    resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
-    prefix: /_wdt
-
-web_profiler_profiler:
-    resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
-    prefix: /_profiler


### PR DESCRIPTION
Fixes the critical information-disclosure issue where the Symfony Web Profiler (`/_profiler`, `/_wdt`, `/_profiler/open`, `/_profiler/phpinfo`, ...) was reachable in the `prod` environment.

## Changes
- `config/bundles.php`: restrict `WebProfilerBundle` to `['dev' => true, 'test' => true]` (was additionally enabled for `prod`). This matches the Symfony default; `DebugBundle`/`MakerBundle` were already `dev`-only.
- Remove `config/routing/dev/web_profiler.yaml`. `config/routes.yaml` imports `config/routing/` as `type: directory`, and the `DirectoryLoader` recursed into `dev/`, registering `/_profiler` and `/_wdt` **without** a `when@dev:` guard. The correctly guarded equivalent already exists at `config/routes/web_profiler.yaml` (auto-loaded per environment by `MicroKernelTrait`), so the profiler still works in `dev`.

## Verification
- `php bin/console debug:router --env=prod` now lists **0** `_profiler*`/`_wdt*` routes (was 14).
- `php bin/console debug:router --env=dev` still lists them (14), so the developer experience is unchanged.
- Container compiles cleanly in both environments.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)