### PR TITLE
Harden production configuration: security headers, secrets, CSRF (#526)

### DIFF
--- a/.env
+++ b/.env
@@ -3,8 +3,11 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
-APP_SECRET=90f2d22c92712fa1cc32be3a26f4e599
+# Production defaults. Override locally via an untracked .env.local
+# (e.g. APP_ENV=dev). Never commit a real APP_SECRET: set it in production
+# exclusively through an environment variable or the Symfony secrets vault.
+APP_ENV=prod
+APP_SECRET=CHANGE_ME_SET_VIA_ENV_OR_SECRETS_VAULT
 ###< symfony/framework-bundle ###
 ###> doctrine/doctrine-bundle ###
 # Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url

--- a/.env.test
+++ b/.env.test
@@ -5,8 +5,6 @@ SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther
 PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 
-ADMIN_PASSWORD=123
-
 
 GRAPH_CACHE_DIRECTORY='/var/www/luft/public/img/graph_cache'
 

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -1,7 +1,7 @@
 # see https://symfony.com/doc/current/reference/configuration/framework.html
 framework:
     secret: '%env(APP_SECRET)%'
-    #csrf_protection: true
+    csrf_protection: true
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.

--- a/src/EventSubscriber/SecurityHeadersSubscriber.php
+++ b/src/EventSubscriber/SecurityHeadersSubscriber.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class SecurityHeadersSubscriber implements EventSubscriberInterface
+{
+    #[\Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'onResponse',
+        ];
+    }
+
+    public function onResponse(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $headers = $response->headers;
+
+        $headers->set('X-Content-Type-Options', 'nosniff', false);
+        $headers->set('X-Frame-Options', 'SAMEORIGIN', false);
+        $headers->set('Referrer-Policy', 'strict-origin-when-cross-origin', false);
+
+        if ($event->getRequest()->isSecure()) {
+            $headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains', false);
+        }
+
+        $this->addContentSecurityPolicy($response);
+    }
+
+    /*
+     * Frame-ancestors is the CSP equivalent of X-Frame-Options and is safe to
+     * enforce without inventorying every external asset host. A full script/style
+     * CSP is intentionally left out here because it requires a frontend asset audit
+     * and runtime verification; see the accompanying pull request for details.
+     */
+    protected function addContentSecurityPolicy(Response $response): void
+    {
+        $response->headers->set("Content-Security-Policy", "frame-ancestors 'self'", false);
+    }
+}


### PR DESCRIPTION
Addresses the production-hardening gaps in #526.

## Changes
- **Security headers:** new `SecurityHeadersSubscriber` on `kernel.response` sets `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security` (only on secure requests), and a `Content-Security-Policy: frame-ancestors 'self'`. Headers are set with `replace=false` so per-controller overrides still win. Registered automatically via `autoconfigure`.
- **CSRF:** enabled `framework.csrf_protection` (`symfony/security-csrf` is already installed). JSON API endpoints are unaffected (form-only feature).
- **APP_SECRET:** committed value replaced with a placeholder; must be provided in production via env var / secrets vault. Rotate the old value where it may have been reused.
- **APP_ENV:** tracked default flipped from `dev` to `prod` so a deploy that forgets to set it does not silently boot in debug/profiler mode. Local development now overrides with `APP_ENV=dev` in the untracked `.env.local`.
- **.env.test:** removed the `ADMIN_PASSWORD=123` default (grep shows zero consumers in `config/`, `src/`, `tests/`).

## Deliberately not implemented
- **Full script/style/connect CSP.** A restrictive `Content-Security-Policy` (script-src, style-src, connect-src, img-src for Leaflet tiles, Algolia autocomplete, fonts, etc.) requires a complete inventory of external asset hosts plus runtime verification of the rendered frontend, which cannot be done safely without a running app (PostGIS/Redis). Only the safe, host-independent `frame-ancestors` directive is enforced here. A follow-up should build the enforced CSP behind report-only first. The issue's suggestion of `nelmio/security-bundle` was not added to avoid a new dependency for the small header set needed today.

## Verification
- `vendor/bin/phpunit --testsuite="Project Test Suite"` — OK (121 tests, 131 assertions)
- `vendor/bin/phpstan analyse --no-progress` — No errors

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)