### PR TITLE
Remove dev-only DomCrawler from production /impress, /privacy, /grenzwerte path (#536)

### DIFF
--- a/config/routing/1_static.yaml
+++ b/config/routing/1_static.yaml
@@ -3,18 +3,21 @@ privacy:
     defaults:
         _controller: App\Controller\TemplateController::staticAction
         templateName: privacy
+        title: 'Datenschutzerklärung'
 
 impress:
     path: /impress
     defaults:
         _controller: App\Controller\TemplateController::staticAction
         templateName: impress
+        title: 'Impressum'
 
 limits:
     path: /grenzwerte
     defaults:
         _controller: App\Controller\TemplateController::staticAction
         templateName: limits
+        title: 'Übersicht über Schadstoffe und Grenzwerte'
 
 pollutant_pm10:
     path: /schadstoffe/feinstaub

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -191,11 +191,6 @@ parameters:
 			path: src/Controller/TemplateController.php
 
 		-
-			message: "#^Ternary operator condition is always true\\.$#"
-			count: 1
-			path: src/Controller/TemplateController.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\<App\\\\Entity\\\\Station\\>\\:\\:findActiveStations\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/TypeaheadController.php

--- a/src/Controller/TemplateController.php
+++ b/src/Controller/TemplateController.php
@@ -4,23 +4,12 @@ namespace App\Controller;
 
 use App\Air\SeoPage\SeoPage;
 use App\Entity\City;
-use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
-use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface;
 use WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs;
 
 class TemplateController extends AbstractController
 {
-    public function __construct(
-        protected EntrypointLookupCollectionInterface $entrypointLookupCollection,
-        ManagerRegistry $managerRegistry
-    )
-    {
-        parent::__construct($managerRegistry);
-    }
-
     public function cityListAction(): Response
     {
         return $this->render(
@@ -30,10 +19,8 @@ class TemplateController extends AbstractController
         );
     }
 
-    public function staticAction(string $templateName, Breadcrumbs $breadcrumbs, RouterInterface $router, SeoPage $seoPage): Response
+    public function staticAction(string $templateName, string $title, Breadcrumbs $breadcrumbs, RouterInterface $router, SeoPage $seoPage): Response
     {
-        $title = $this->readH2Tag($templateName);
-
         $templateFilename = sprintf('Static/%s.html.twig', $templateName);
 
         $seoPage->setTitle($title);
@@ -43,20 +30,5 @@ class TemplateController extends AbstractController
             ->addItem($title);
 
         return $this->render($templateFilename);
-    }
-
-    protected function readH2Tag(string $templateName): ?string
-    {
-        $templateFilename = sprintf('Static/%s.html.twig', $templateName);
-
-        $templateContent = $this->renderView($templateFilename);
-
-        $crawler = new Crawler($templateContent);
-        $h2 = $crawler->filter('h2')->first();
-
-        /** @see https://github.com/symfony/webpack-encore-bundle/issues/73#issuecomment-514649426 */
-        $this->entrypointLookupCollection->getEntrypointLookup()->reset();
-
-        return $h2 ? $h2->text() : null;
     }
 }


### PR DESCRIPTION
## Summary
`TemplateController::staticAction` (routes `/privacy`, `/impress`, `/grenzwerte`) derived the page title by rendering the template a **second time** and parsing its `<h2>` with `Symfony\Component\DomCrawler\Crawler` + `->filter()` (which additionally needs `symfony/css-selector`). Both `symfony/dom-crawler` and `symfony/css-selector` are **`require-dev`-only** (pulled transitively via `symfony/browser-kit`), so a production build with `composer install --no-dev` fatals with `Class Symfony\Component\DomCrawler\Crawler not found` on all three routes.

## Changes
- Replaced the H2 parsing with an explicit `title` route default in `config/routing/1_static.yaml` (`Datenschutzerklärung` / `Impressum` / `Übersicht über Schadstoffe und Grenzwerte`), matching the exact previous H2 text. `staticAction` now takes a `string $title` argument bound from the route default.
- Removed `readH2Tag()` and with it:
  - the double full render of every static template per request,
  - the `EntrypointLookup` reset workaround and the now-unused `EntrypointLookupCollectionInterface` constructor dependency (the constructor is gone; `ManagerRegistry` comes from the parent),
  - the always-true ternary `$h2 ? $h2->text() : null` and its `phpstan-baseline.neon` entry.
- No production code references `DomCrawler`/`CssSelector` anymore; they remain dev-only (still used by `browser-kit` in the Integration test suite).

## Deliberately not implemented
- **Caching the remote Impress JSON** (optional item): out of scope for this fix; the double-render that amplified the external call is already removed.
- **A `--no-dev` smoke-build CI job** (optional item): worth adding as a guard, but left as a follow-up to avoid coupling this focused fix to CI-pipeline changes.

## Verification
- `grep` confirms no `DomCrawler`/`CssSelector`/`Crawler`/`EntrypointLookupCollection` references remain in `src/`.
- `vendor/bin/phpstan analyse` — No errors (baseline entry removed).
- `vendor/bin/phpunit --testsuite="Project Test Suite"` — 121 tests green.
- `bin/console lint:container --env=prod` — OK.
- `bin/console debug:router privacy --env=prod` — shows `title: Datenschutzerklärung` default.

Note: the `/impress` and `/privacy` Integration tests assert on the template's own `<h2>` (not the SEO title), so behaviour is unchanged; they run in the DB/network-dependent Integration suite, not exercised here.

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)