### PR TITLE
API-CORS + Typeahead-Dropdown beheben, Impressum/Datenschutz-Fixes

### DIFF
--- a/assets/scss/typeahead.scss
+++ b/assets/scss/typeahead.scss
@@ -76,18 +76,10 @@
   max-width: 100% !important;
   margin-top: 8px;
   overflow: hidden;
-  animation: slideDown 0.15s ease-out;
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  // Kein Einblend-Animation (slideDown): autocomplete-js baut den Panel bei JEDEM Render neu
+  // (jeder Tastendruck + das asynchrone Nachladen der "Orte"-Quelle). Eine CSS-Entry-Animation
+  // feuerte dadurch bei jeder Eingabe erneut und ließ den Panel dauerhaft flackern/durchscheinen
+  // (opacity 0 -> 1 pro Render). Ohne Animation erscheint das Dropdown sofort deckend.
 }
 
 .aa-PanelLayout {

--- a/src/EventSubscriber/CorsSubscriber.php
+++ b/src/EventSubscriber/CorsSubscriber.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * CORS für die öffentliche, lesende API unter /api. Wird u. a. von den statischen
+ * Schwester-Apps (uvindex.jetzt usw.) direkt aus dem Browser abgerufen; ohne
+ * Access-Control-Allow-Origin blockt der Browser den Cross-Origin-Fetch ("Daten nicht
+ * verfügbar"). Es werden ausschließlich öffentliche Messwerte ohne Cookies/Credentials
+ * ausgeliefert, daher ist ein offener Origin ("*") unbedenklich und am robustesten.
+ *
+ * Bewusst als schlanker Subscriber statt nelmio/cors-bundle: nelmio 2.x ist nicht mit
+ * Symfony 8 kompatibel (framework-bundle < 8.0).
+ */
+class CorsSubscriber implements EventSubscriberInterface
+{
+    private const string API_PREFIX = '/api';
+
+    #[\Override]
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Vor dem Router: OPTIONS-Preflight direkt beantworten (sonst 404 im Router).
+            KernelEvents::REQUEST => ['onRequest', 8],
+            KernelEvents::RESPONSE => 'onResponse',
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if ($request->getMethod() === 'OPTIONS' && $this->isApiPath($request->getPathInfo())) {
+            $response = new Response('', Response::HTTP_NO_CONTENT);
+            $this->addCorsHeaders($response);
+            $event->setResponse($response);
+        }
+    }
+
+    public function onResponse(ResponseEvent $event): void
+    {
+        if ($this->isApiPath($event->getRequest()->getPathInfo())) {
+            $this->addCorsHeaders($event->getResponse());
+        }
+    }
+
+    private function isApiPath(string $pathInfo): bool
+    {
+        return $pathInfo === self::API_PREFIX || str_starts_with($pathInfo, self::API_PREFIX.'/');
+    }
+
+    private function addCorsHeaders(Response $response): void
+    {
+        $response->headers->set('Access-Control-Allow-Origin', '*');
+        $response->headers->set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        $response->headers->set('Access-Control-Allow-Headers', 'Content-Type');
+        $response->headers->set('Access-Control-Max-Age', '86400');
+    }
+}

--- a/templates/Includes/footer.html.twig
+++ b/templates/Includes/footer.html.twig
@@ -12,6 +12,16 @@
                     <a href="http://github.com/luft-jetzt">GitHub</a>
                     &bull;
                     <a href="{{ path('app.swagger_ui') }}">Api</a>
+                <br />
+                    <a href="https://luft.jetzt">luft.jetzt</a>
+                    &bull;
+                    <a href="https://hitze.jetzt">hitze.jetzt</a>
+                    &bull;
+                    <a href="https://uvindex.jetzt">uvindex.jetzt</a>
+                    &bull;
+                    <a href="https://waldbrand.jetzt">waldbrand.jetzt</a>
+                    &bull;
+                    <a href="https://pollenflug.jetzt">pollenflug.jetzt</a>
                 </p>
             </div>
         </div>

--- a/templates/Static/impress.html.twig
+++ b/templates/Static/impress.html.twig
@@ -13,17 +13,17 @@
             </p>
 
             <p>
-                {{ impress_property('firstName') }} {{ impress_property('lastName') }}
+                Malte Hübner
                 <br />
-                {{ impress_property('street') }} {{ impress_property('houseNumber') }}
+                Goethestraße 48
                 <br />
-                {{ impress_property('zipCode') }} {{ impress_property('city') }}
+                21335 Lüneburg
             </p>
 
             <p>
-                Telefon: {{ impress_property('phoneNumber') }}
+                Telefon: 04131 7073396
                 <br/>
-                E-Mail: <a href="mailto:luft@caldera.cc">luft@caldera.cc</a>
+                E-Mail: <a href="mailto:maltehuebner@gmx.org">maltehuebner@gmx.org</a>
             </p>
 
             <p>

--- a/templates/static/privacy.html.twig
+++ b/templates/static/privacy.html.twig
@@ -17,17 +17,17 @@
             </h3>
 
             <p>
-                {{ impress_property('firstName') }} {{ impress_property('lastName') }}
+                Malte Hübner
                 <br />
-                {{ impress_property('street') }} {{ impress_property('houseNumber') }}
+                Goethestraße 48
                 <br />
-                {{ impress_property('zipCode') }} {{ impress_property('city') }}
+                21335 Lüneburg
             </p>
 
             <p>
-                Telefon: {{ impress_property('phoneNumber') }}
+                Telefon: 04131 7073396
                 <br/>
-                E-Mail: <a href="mailto:luft@caldera.cc">luft@caldera.cc</a>
+                E-Mail: <a href="mailto:maltehuebner@gmx.org">maltehuebner@gmx.org</a>
             </p>
 
             <h3>


### PR DESCRIPTION
Behebt drei heute in Produktion aufgefallene Probleme (alle bereits live auf server2 deployt):

## 1. CORS für die /api-Endpunkte
Die statischen Schwester-Apps (z. B. **uvindex.jetzt**) holen ihre Daten per Browser-`fetch` von `luft.jetzt/api`. Ohne `Access-Control-Allow-Origin` blockte der Browser den Cross-Origin-Abruf → „Daten nicht verfügbar".

- Neuer `App\EventSubscriber\CorsSubscriber`: setzt für `/api`-Pfade `Access-Control-Allow-Origin: *` (öffentliche, lesende Messwert-API, keine Credentials) und beantwortet den OPTIONS-Preflight mit 204.
- Bewusst **kein** `nelmio/cors-bundle` (2.x ist mit Symfony 8 inkompatibel, `framework-bundle < 8.0`).

## 2. Typeahead-Dropdown flackert / scheint durch
Das `.aa-Panel` hatte eine `slideDown`-Einblendanimation, die bei **jedem** autocomplete-js-Render (jeder Tastendruck + asynchrones „Orte"-Nachladen) neu feuerte → dauerhaftes Flackern und halbtransparentes Panel. Animation entfernt.

## 3. Impressum/Datenschutz warfen HTTP 500
`impress`/`privacy` zogen Name/Anschrift aus einer toten Remote-JSON (`maltehuebner.de/malte.json` → 404) → beide Seiten 500. Jetzt feste Angaben (Malte Hübner, Anschrift, Telefon, E-Mail). Zusätzlich Footer-Cross-Links zu den Schwesterseiten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)