### PR TITLE
UV-Messwerte: Bundesamt für Strahlenschutz ausweisen + Stationsseite verlinken

### DIFF
--- a/src/Twig/Extension/BfsUvTwigExtension.php
+++ b/src/Twig/Extension/BfsUvTwigExtension.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Verlinkt eine UV-Messstation auf ihre Tagesverlauf-Seite beim Bundesamt für Strahlenschutz (BfS),
+ * das die UV-Messwerte liefert.
+ *
+ * Zuordnung station_code → BfS-Slug ist fest hinterlegt und am 25.07.2026 verifiziert (jede URL
+ * liefert HTTP 200). Eine Ableitung aus dem Stationsnamen ist nicht zuverlässig, da die
+ * luft.jetzt-Titel von den BfS-Namen abweichen (z. B. „Schneefernerhaus an der Zugspitze" → slug
+ * `zugspitze`). Fulda (BFS678) hat keine BfS-Tagesverlauf-Seite und ist daher nicht enthalten.
+ */
+class BfsUvTwigExtension extends AbstractExtension
+{
+    private const string BASE_URL =
+        'https://www.bfs.de/DE/themen/opt/uv/uv-index/aktuelle-tagesverlaeufe/_documents/%s_node.html';
+
+    /** @var array<string, string> station_code => BfS-Slug */
+    private const array STATION_SLUGS = [
+        'BFS360' => 'andernach', 'BFS87' => 'osnabrueck', 'GAAHI746' => 'boesel', 'BFS912' => 'chieming',
+        'GAAHI750' => 'cuxhaven', 'BAUA511' => 'dortmund', 'GAAHI404' => 'duderstadt', 'BFS382' => 'eckernfoerde',
+        'BFS861' => 'fichtelberg', 'BFS59' => 'friedrichshafen', 'BFS363' => 'genthin', 'BFS378' => 'giessen',
+        'BFS427' => 'groemitz', 'BFS11' => 'goerlitz', 'BFS864' => 'hamburg', 'DWD520' => 'hohenpeissenberg',
+        'BFS328' => 'klippeneck', 'BFS762' => 'kulmbach', 'UBA833' => 'langen', 'DWD611' => 'lindenberg',
+        'GAAHI658' => 'lueneburg', 'TROPOS140' => 'melpitz', 'BFS935' => 'muenchen', 'GAAHI768' => 'norderney',
+        'BFS723' => 'salzgitter', 'BFS572' => 'kassel', 'UBA301' => 'schauinsland', 'BFS622' => 'zugspitze',
+        'BFS885' => 'schweinfurt', 'BFS799' => 'stuttgart', 'BFS613' => 'sylt', 'BFS362' => 'tholey',
+        'BFS478' => 'todendorf', 'BFS486' => 'waldhof', 'BFS375' => 'waldmuenchen', 'BFS161' => 'weissenburg',
+        'GAAHI272' => 'wurmberg', 'UBA378' => 'zingst', 'BFS213' => 'zirchow',
+    ];
+
+    #[\Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('bfs_uv_station_url', $this->bfsUvStationUrl(...)),
+        ];
+    }
+
+    /**
+     * @return string|null Die BfS-Tagesverlauf-URL der Station oder null, wenn keine bekannt ist.
+     */
+    public function bfsUvStationUrl(?string $stationCode): ?string
+    {
+        if ($stationCode === null || !isset(self::STATION_SLUGS[$stationCode])) {
+            return null;
+        }
+
+        return sprintf(self::BASE_URL, self::STATION_SLUGS[$stationCode]);
+    }
+}

--- a/templates/Default/_box.html.twig
+++ b/templates/Default/_box.html.twig
@@ -60,6 +60,15 @@
 
         </p>
         {% if stationLink %}</a>{% endif %}
+
+        {% if view_model.pollutant.identifier == 'uvindex' %}
+            {% set bfsUrl = bfs_uv_station_url(view_model.station.stationCode) %}
+            <p class="card-text mb-0"><small>
+                UV-Messwerte:
+                <a href="https://www.bfs.de/DE/themen/opt/uv/uv-index/" class="text-white text-decoration-underline" target="_blank" rel="noopener">Bundesamt für Strahlenschutz</a>{% if bfsUrl %}
+                &middot; <a href="{{ bfsUrl }}" class="text-white text-decoration-underline" target="_blank" rel="noopener" title="Tagesverlauf dieser Station beim BfS">Tagesverlauf&nbsp;<i class="fa fa-external-link"></i></a>{% endif %}
+            </small></p>
+        {% endif %}
     </div>
 
     {% if not combined %}


### PR DESCRIPTION
Weist bei UV-Messwerten (Pollutant `uvindex`) das **Bundesamt für Strahlenschutz (BfS)** als Quelle aus und verlinkt die BfS-Tagesverlauf-Seite der jeweiligen Station.

## Änderungen
- **`BfsUvTwigExtension`** (neu): Twig-Funktion `bfs_uv_station_url(stationCode)` → URL der BfS-Tagesverlauf-Seite oder `null`. Die `station_code → BfS-Slug`-Zuordnung ist fest hinterlegt und am 25.07.2026 per HTTP verifiziert (jede URL liefert 200). Eine Ableitung aus dem Stationsnamen ist unzuverlässig, da die luft.jetzt-Titel von den BfS-Namen abweichen (z. B. „Schneefernerhaus an der Zugspitze" → Slug `zugspitze`). Fulda (BFS678) hat keine BfS-Seite → kein Link.
- **`_box.html.twig`**: bei UV-Boxen ein Quellenhinweis „UV-Messwerte: Bundesamt für Strahlenschutz · Tagesverlauf ↗".

Bereits live deployt und auf `/GAAHI658` (Messstation Lüneburg) verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)