### PR TITLE
Neugestaltung Atmosphäre — Start, Ergebnis, Station & Stadt im neuen Design

### DIFF
--- a/assets/js/atmosphaere.js
+++ b/assets/js/atmosphaere.js
@@ -1,0 +1,140 @@
+// luft.jetzt · Atmosphäre — schlanker JS-Layer für Start/Ergebnis.
+// Geolocation + Autocomplete auf den bestehenden Endpunkten, ohne Bootstrap/Algolia.
+
+const PREFETCH_CITIES = '/search/prefetch-cities';
+const PREFETCH_STATIONS = '/search/prefetch-stations';
+const GEOCODE = '/search/query';
+
+function initGeolocation() {
+    const btn = document.querySelector('[data-at-geolocate]');
+    if (!btn) return;
+    const error = document.querySelector('[data-at-geo-error]');
+
+    btn.addEventListener('click', () => {
+        if (!navigator.geolocation) {
+            if (error) { error.textContent = 'Standort wird von diesem Browser nicht unterstützt.'; error.hidden = false; }
+            return;
+        }
+        btn.classList.add('is-loading');
+        btn.disabled = true;
+        if (error) error.hidden = true;
+
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                window.location = '/display?latitude=' + encodeURIComponent(pos.coords.latitude) + '&longitude=' + encodeURIComponent(pos.coords.longitude);
+            },
+            (err) => {
+                btn.classList.remove('is-loading');
+                btn.disabled = false;
+                if (error) {
+                    error.textContent = err && err.code === err.PERMISSION_DENIED
+                        ? 'Standortzugriff abgelehnt. Bitte gib deinen Ort ein.'
+                        : 'Dein Standort konnte nicht ermittelt werden. Bitte gib deinen Ort ein.';
+                    error.hidden = false;
+                }
+            },
+            { enableHighAccuracy: false, timeout: 15000, maximumAge: 300000 }
+        );
+    });
+}
+
+function initSearch() {
+    const input = document.querySelector('[data-at-search]');
+    const panel = document.querySelector('[data-at-results]');
+    if (!input || !panel) return;
+
+    let cities = [], stations = [];
+    let debounce, geoCtrl, geoSeq = 0, places = [], options = [], active = -1;
+
+    Promise.all([
+        fetch(PREFETCH_CITIES).then((r) => r.ok ? r.json() : []),
+        fetch(PREFETCH_STATIONS).then((r) => r.ok ? r.json() : []),
+    ]).then(([c, s]) => { cities = c || []; stations = s || []; }).catch(() => {});
+
+    const filter = (list, q, key) => {
+        const n = q.toLowerCase(), out = [];
+        for (const item of list) {
+            const v = item.value;
+            const hay = (key === 'station' ? (v.title + ' ' + v.stationCode) : v.name).toLowerCase();
+            if (hay.includes(n)) { out.push(v); if (out.length >= 5) break; }
+        }
+        return out;
+    };
+
+    const close = () => { panel.hidden = true; panel.innerHTML = ''; options = []; active = -1; };
+
+    const render = (q) => {
+        const cM = filter(cities, q, 'city');
+        const sM = filter(stations, q, 'station');
+        panel.innerHTML = '';
+        options = [];
+
+        const group = (label, items, build) => {
+            if (!items.length) return;
+            const h = document.createElement('div'); h.className = 'at-results__group'; h.textContent = label;
+            panel.appendChild(h);
+            items.forEach((it) => {
+                const el = document.createElement('a'); el.className = 'at-results__item'; el.href = '#';
+                build(el, it);
+                el.addEventListener('mousedown', (e) => { e.preventDefault(); go(it); });
+                panel.appendChild(el);
+                options.push({ data: it, el });
+            });
+        };
+
+        group('Städte', cM, (el, c) => { el.textContent = c.name; el.dataset.type = 'nav'; el.dataset.url = c.url; });
+        group('Messstationen', sM, (el, s) => {
+            el.innerHTML = '<span>' + s.title + '</span><small>' + s.stationCode + '</small>';
+            el.dataset.type = 'nav'; el.dataset.url = s.url;
+        });
+        group('Orte', places, (el, p) => {
+            const label = [p.name, p.zipCode, p.city].filter(Boolean).join(' · ');
+            el.textContent = label || (p.city || 'Ort');
+            el.dataset.type = 'coord'; el.dataset.lat = p.latitude; el.dataset.lon = p.longitude;
+        });
+
+        panel.hidden = options.length === 0;
+    };
+
+    const go = (item) => {
+        if (item.url) { window.location = item.url; return; }
+        if (item.latitude != null) { window.location = '/display?latitude=' + encodeURIComponent(item.latitude) + '&longitude=' + encodeURIComponent(item.longitude); }
+    };
+
+    const searchPlaces = (q) => {
+        if (geoCtrl) geoCtrl.abort();
+        geoCtrl = new AbortController();
+        const seq = ++geoSeq;
+        fetch(GEOCODE + '?query=' + encodeURIComponent(q), { signal: geoCtrl.signal })
+            .then((r) => r.ok ? r.json() : [])
+            .then((data) => {
+                if (seq !== geoSeq) return;
+                places = (Array.isArray(data) ? data : []).map((d) => d.value).filter(Boolean).slice(0, 5);
+                render(input.value.trim());
+            })
+            .catch(() => {});
+    };
+
+    input.addEventListener('input', () => {
+        const q = input.value.trim();
+        window.clearTimeout(debounce);
+        if (q.length < 2) { places = []; close(); return; }
+        render(q);
+        if (q.length >= 3) debounce = window.setTimeout(() => searchPlaces(q), 260);
+    });
+
+    input.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowDown' && options.length) { e.preventDefault(); active = (active + 1) % options.length; highlight(); }
+        else if (e.key === 'ArrowUp' && options.length) { e.preventDefault(); active = (active - 1 + options.length) % options.length; highlight(); }
+        else if (e.key === 'Enter' && options.length) { e.preventDefault(); go(options[active >= 0 ? active : 0].data); }
+        else if (e.key === 'Escape') close();
+    });
+
+    const highlight = () => options.forEach((o, i) => o.el.classList.toggle('is-active', i === active));
+
+    document.addEventListener('click', (e) => { if (!panel.contains(e.target) && e.target !== input) close(); });
+}
+
+function init() { initGeolocation(); initSearch(); }
+if (document.readyState !== 'loading') init();
+else document.addEventListener('DOMContentLoaded', init);

--- a/assets/js/atmosphaere.js
+++ b/assets/js/atmosphaere.js
@@ -1,5 +1,8 @@
-// luft.jetzt · Atmosphäre — schlanker JS-Layer für Start/Ergebnis.
+// luft.jetzt · Atmosphäre — schlanker JS-Layer für Start/Ergebnis/Karte.
 // Geolocation + Autocomplete auf den bestehenden Endpunkten, ohne Bootstrap/Algolia.
+// Leaflet wird nur bei Bedarf (Kartenseite) dynamisch nachgeladen.
+
+const AQI = { 1: '#1fb3a6', 2: '#74c247', 3: '#f2c33c', 4: '#e8683c', 5: '#a83d6b' };
 
 const PREFETCH_CITIES = '/search/prefetch-cities';
 const PREFETCH_STATIONS = '/search/prefetch-stations';
@@ -135,6 +138,44 @@ function initSearch() {
     document.addEventListener('click', (e) => { if (!panel.contains(e.target) && e.target !== input) close(); });
 }
 
-function init() { initGeolocation(); initSearch(); }
+async function initMaps() {
+    const containers = document.querySelectorAll('[data-at-map]');
+    if (!containers.length) return;
+
+    const { default: L } = await import('leaflet');
+
+    containers.forEach((el) => {
+        let stations = [], me = null;
+        try { stations = JSON.parse(el.dataset.atStations || '[]'); } catch (e) { /* noop */ }
+        try { me = el.dataset.atMe ? JSON.parse(el.dataset.atMe) : null; } catch (e) { /* noop */ }
+        if (!stations.length && !me) return;
+
+        const map = L.map(el, { scrollWheelZoom: false, attributionControl: true });
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenStreetMap', maxZoom: 19,
+        }).addTo(map);
+
+        const pts = [];
+        stations.forEach((s) => {
+            if (typeof s.lat !== 'number' || typeof s.lon !== 'number') return;
+            const marker = L.circleMarker([s.lat, s.lon], {
+                radius: 8, color: '#fff', weight: 2, opacity: 0.9,
+                fillColor: AQI[s.level] || 'rgba(255,255,255,.6)', fillOpacity: 1,
+            }).addTo(map);
+            if (s.name) marker.bindPopup(s.name + (s.code ? ' · ' + s.code : ''));
+            if (s.url) marker.on('click', () => { window.location = s.url; });
+            pts.push([s.lat, s.lon]);
+        });
+        if (me && typeof me.lat === 'number') {
+            L.circleMarker([me.lat, me.lon], { radius: 7, color: '#fff', weight: 3, fillColor: '#4a86c5', fillOpacity: 1 })
+                .addTo(map).bindPopup('Dein Standort');
+            pts.push([me.lat, me.lon]);
+        }
+        if (pts.length === 1) map.setView(pts[0], 12);
+        else if (pts.length) map.fitBounds(pts, { padding: [28, 28], maxZoom: 13 });
+    });
+}
+
+function init() { initGeolocation(); initSearch(); initMaps(); }
 if (document.readyState !== 'loading') init();
 else document.addEventListener('DOMContentLoaded', init);

--- a/assets/js/atmosphaere.js
+++ b/assets/js/atmosphaere.js
@@ -176,6 +176,21 @@ async function initMaps() {
     });
 }
 
-function init() { initGeolocation(); initSearch(); initMaps(); }
+function initTimeAgo() {
+    const fmt = (ts) => {
+        const diff = Math.floor(Date.now() / 1000 - ts);
+        if (diff < 0) return 'gerade eben';
+        if (diff < 90) return 'gerade eben';
+        if (diff < 3600) return 'vor ' + Math.floor(diff / 60) + ' Min';
+        if (diff < 86400) return 'vor ' + Math.round(diff / 3600) + ' Std';
+        return 'vor ' + Math.round(diff / 86400) + ' Tg';
+    };
+    document.querySelectorAll('[data-time-ago-timestamp]').forEach((el) => {
+        const ts = parseInt(el.dataset.timeAgoTimestamp, 10);
+        if (ts) { el.textContent = fmt(ts); el.title = el.dataset.timeAgoTitle || el.title; }
+    });
+}
+
+function init() { initGeolocation(); initSearch(); initMaps(); initTimeAgo(); }
 if (document.readyState !== 'loading') init();
 else document.addEventListener('DOMContentLoaded', init);

--- a/assets/scss/atmosphaere.scss
+++ b/assets/scss/atmosphaere.scss
@@ -190,3 +190,31 @@
   .at-page::before { content:""; position: fixed; inset: 0; pointer-events: none;
     box-shadow: inset 0 0 140px rgba(0,0,0,.28); }
 }
+
+// ---------- Autocomplete-Dropdown (Start) -----------------------------------
+.at-searchbox { position: relative; }
+.at-results {
+  position: absolute; z-index: 30; inset-inline: 0; top: calc(100% + 8px);
+  background: rgba(20, 28, 42, 0.72); border: 1px solid var(--at-glass-brd);
+  border-radius: var(--at-r-md); overflow: hidden; padding: 6px;
+  backdrop-filter: blur(18px) saturate(140%); -webkit-backdrop-filter: blur(18px) saturate(140%);
+  box-shadow: 0 24px 60px -24px rgba(0,0,0,.6); max-height: 60vh; overflow-y: auto;
+}
+.at-results__group { font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; opacity: .6; padding: 8px 10px 4px; }
+.at-results__item {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+  padding: 10px 10px; border-radius: 10px; color: #fff; text-decoration: none; font-size: 14px;
+  &:hover, &.is-active { background: rgba(255,255,255,.14); }
+  small { opacity: .6; font-family: var(--at-mono); font-size: 11px; }
+}
+
+// Geolocation-Button Ladezustand
+.at-cta.is-loading { color: transparent; position: relative; pointer-events: none; }
+.at-cta.is-loading::after {
+  content: ""; position: absolute; inset: 0; margin: auto; width: 18px; height: 18px;
+  border: 2px solid rgba(15,32,56,.35); border-top-color: #0f2038; border-radius: 50%;
+  animation: at-spin .7s linear infinite;
+}
+@keyframes at-spin { to { transform: rotate(360deg); } }
+.at-geo-error { margin-top: 10px; font-size: 12.5px; color: #ffd9d0; }
+@media (prefers-reduced-motion: reduce) { .at-cta.is-loading::after { animation: none; } }

--- a/assets/scss/atmosphaere.scss
+++ b/assets/scss/atmosphaere.scss
@@ -1,0 +1,155 @@
+// =============================================================================
+// luft.jetzt · Atmosphäre — Design-System (Prototyp 01, freigegeben)
+// Eigenständiger Encore-Style-Entry, isoliert vom bestehenden Bootstrap-Frontend,
+// damit das neue Design wachsen kann, ohne die Live-Seiten anzufassen.
+// Prinzip: „Der Himmel liest die Luft" — der Verlauf verschiebt sich mit dem Index.
+// =============================================================================
+
+// ---------- Tokens ----------------------------------------------------------
+:root {
+  // Luftqualitätsindex (semantisch — in der ganzen App identisch)
+  --aqi-1: #1fb3a6; // sehr gut
+  --aqi-2: #74c247; // gut
+  --aqi-3: #f2c33c; // mäßig
+  --aqi-4: #e8683c; // schlecht
+  --aqi-5: #a83d6b; // sehr schlecht
+
+  --at-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  --at-mono: ui-monospace, "SF Mono", "Cascadia Code", "Roboto Mono", Menlo, monospace;
+
+  // Glas
+  --at-glass-bg: rgba(255, 255, 255, 0.14);
+  --at-glass-brd: rgba(255, 255, 255, 0.22);
+  --at-glass-blur: 14px;
+
+  // Radien
+  --at-r-lg: 24px;
+  --at-r-md: 16px;
+  --at-r-sm: 12px;
+}
+
+// ---------- Himmel-Zustände (der Kern) --------------------------------------
+// Jede Stufe setzt drei Verlaufsstopps + Dunst-Intensität + Akzentpunkt.
+.at-sky {
+  position: relative;
+  overflow: hidden;
+  color: #fff;
+  font-family: var(--at-sans);
+  background:
+    radial-gradient(135% 85% at 78% -8%, rgba(255, 255, 255, 0.30), transparent 52%),
+    linear-gradient(180deg, var(--s1) 0%, var(--s2) 54%, var(--s3) 100%);
+  transition: background 0.7s ease;
+
+  // Dunstband unten (Sicht sinkt mit schlechter Luft)
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(120% 42% at 50% 100%, rgba(244, 247, 250, 1), transparent 72%);
+    opacity: var(--haze);
+    mix-blend-mode: screen;
+  }
+  // feine Partikel-Textur, wird mit Dunst dichter
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: calc(var(--haze) * 0.5);
+    background-image: radial-gradient(rgba(255, 255, 255, 0.5) 0.6px, transparent 0.7px);
+    background-size: 7px 7px;
+  }
+}
+
+.at-lv1 { --s1:#0e2f5a; --s2:#3f86c9; --s3:#d4e8f6; --at-dot:var(--aqi-1); --haze:0.32; }
+.at-lv2 { --s1:#173a63; --s2:#4a86c5; --s3:#bdd8ea; --at-dot:var(--aqi-2); --haze:0.50; }
+.at-lv3 { --s1:#2c3a54; --s2:#7e86a2; --s3:#e7d4a2; --at-dot:var(--aqi-3); --haze:0.62; }
+.at-lv4 { --s1:#3a2d38; --s2:#9a6a52; --s3:#e3ab79; --at-dot:var(--aqi-4); --haze:0.72; }
+.at-lv5 { --s1:#241f2b; --s2:#6a5563; --s3:#b3a2a7; --at-dot:var(--aqi-5); --haze:0.84; }
+.at-idle { --s1:#1c2145; --s2:#454a78; --s3:#8a7c94; --at-dot:#cfd6e6; --haze:0.30; } // Start/ohne Ort
+
+// Inhalt über den Pseudo-Elementen
+.at-sky > * { position: relative; z-index: 1; }
+
+// ---------- Glas-Bausteine --------------------------------------------------
+.at-glass {
+  background: var(--at-glass-bg);
+  border: 1px solid var(--at-glass-brd);
+  backdrop-filter: blur(var(--at-glass-blur));
+  -webkit-backdrop-filter: blur(var(--at-glass-blur));
+}
+
+// ---------- Screen-Grundgerüst ----------------------------------------------
+.at-screen { min-height: 100%; display: flex; flex-direction: column; }
+.at-body { padding: 24px 22px 26px; position: relative; flex: 1; display: flex; flex-direction: column; }
+
+.at-head { display: flex; justify-content: space-between; align-items: center; font-size: 14px; }
+.at-head .at-loc { font-weight: 600; }
+.at-head .at-loc small { display: block; font-weight: 400; opacity: 0.75; font-size: 11.5px; }
+.at-iconbtn {
+  width: 34px; height: 34px; border-radius: 50%;
+  display: grid; place-items: center; color: #fff;
+  background: var(--at-glass-bg); border: 1px solid var(--at-glass-brd);
+  backdrop-filter: blur(6px);
+}
+
+// ---------- Hero (Urteil) ---------------------------------------------------
+.at-hero { text-align: center; margin: 28px 0 8px; }
+.at-hero__idx { font-size: 12px; letter-spacing: 0.22em; text-transform: uppercase; opacity: 0.85; }
+.at-hero__verdict { font-size: 60px; font-weight: 300; letter-spacing: -0.02em; line-height: 1; margin: 8px 0 6px; }
+.at-hero__sub { font-size: 14px; opacity: 0.92; max-width: 26ch; margin-inline: auto; }
+.at-scale {
+  height: 6px; border-radius: 999px; margin: 22px 4px 0; position: relative;
+  background: linear-gradient(90deg, var(--aqi-1), var(--aqi-2), var(--aqi-3), var(--aqi-4), var(--aqi-5));
+  b {
+    position: absolute; top: 50%; width: 14px; height: 14px; border-radius: 50%;
+    background: #fff; transform: translate(-50%, -50%);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.32);
+    transition: left 0.7s ease;
+  }
+}
+
+// ---------- Schadstoff-Chips ------------------------------------------------
+.at-chips { display: flex; gap: 10px; overflow-x: auto; padding: 20px 2px 4px; scrollbar-width: none; }
+.at-chips::-webkit-scrollbar { display: none; }
+.at-chip {
+  flex: 0 0 auto; min-width: 90px; padding: 13px 14px; border-radius: 18px;
+  .at-chip__k { font-size: 11px; opacity: 0.8; }
+  .at-chip__v { font-size: 22px; font-weight: 600; margin-top: 3px; font-variant-numeric: tabular-nums; }
+  .at-chip__v small { font-size: 11px; font-weight: 400; opacity: 0.8; }
+  .at-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; margin-right: 5px; vertical-align: 1px; }
+}
+
+// ---------- Schadstoff-Liste (Stationsseite) --------------------------------
+.at-list .at-row {
+  display: grid; grid-template-columns: 1fr auto 56px; gap: 12px; align-items: center;
+  padding: 12px 0; border-top: 1px solid rgba(255, 255, 255, 0.16);
+}
+.at-list .at-row__nm { font-size: 13.5px; }
+.at-list .at-row__nm i { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 8px; }
+.at-list .at-row__v { font-size: 14.5px; font-weight: 600; text-align: right; font-variant-numeric: tabular-nums; }
+.at-list .at-row__v small { font-weight: 400; opacity: 0.75; font-size: 10.5px; }
+.at-list .at-row svg { width: 56px; height: 20px; display: block; }
+
+.at-foot { margin-top: 16px; font-size: 11.5px; opacity: 0.82; text-align: center; }
+.at-foot a { color: #fff; }
+
+// ---------- Start / Standort ------------------------------------------------
+.at-start__big { margin-top: 60px; font-size: 30px; font-weight: 300; line-height: 1.16; letter-spacing: -0.01em; }
+.at-search {
+  margin-top: 22px; border-radius: var(--at-r-md); padding: 13px 15px;
+  display: flex; align-items: center; gap: 10px; color: #fff;
+  input { all: unset; flex: 1; color: #fff; font-size: 14px; &::placeholder { color: rgba(255, 255, 255, 0.7); } }
+}
+.at-cta {
+  margin-top: 12px; border-radius: var(--at-r-md); padding: 14px; text-align: center;
+  font-weight: 600; font-size: 14px; color: #0f2038; background: rgba(255, 255, 255, 0.92);
+  border: none; width: 100%; cursor: pointer;
+  &--ghost { background: transparent; color: #fff; border: 1px solid rgba(255, 255, 255, 0.4); font-weight: 500; }
+}
+.at-start__hint { margin-top: auto; padding-top: 40px; font-size: 11.5px; opacity: 0.78; text-align: center; }
+
+@media (prefers-reduced-motion: reduce) {
+  .at-sky, .at-scale b { transition: none; }
+}

--- a/assets/scss/atmosphaere.scss
+++ b/assets/scss/atmosphaere.scss
@@ -153,3 +153,40 @@
 @media (prefers-reduced-motion: reduce) {
   .at-sky, .at-scale b { transition: none; }
 }
+
+// ---------- Vollseiten-Layout (echte Seiten) --------------------------------
+// Der Himmel füllt den ganzen Viewport; der Inhalt sitzt in einer app-artigen
+// Spalte, damit es auf dem Desktop wie eine App wirkt statt breitzulaufen.
+.at-page { min-height: 100dvh; display: flex; flex-direction: column; }
+.at-shell { width: min(540px, 100%); margin-inline: auto; padding: 20px 20px 44px; flex: 1; display: flex; flex-direction: column; color: #fff; }
+
+.at-topbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.at-brand { color: #fff; font-weight: 600; text-decoration: none; font-size: 17px; letter-spacing: -.01em; }
+.at-brand span { opacity: .68; font-weight: 400; }
+.at-topbar__actions { display: flex; gap: 8px; }
+
+// Kompakter Header für Detailseiten (Station)
+.at-detailhead { display: flex; align-items: center; gap: 12px; margin-top: 8px; }
+.at-detailhead .at-title { font-weight: 600; font-size: 15px; }
+.at-mini-hero { margin: 20px 0 8px; }
+.at-mini-hero .at-word { font-size: 40px; font-weight: 300; letter-spacing: -.02em; line-height: 1; }
+.at-mini-hero .at-meta { font-size: 12.5px; opacity: .85; margin-top: 8px; }
+.at-mini-hero .at-scale { max-width: 320px; margin-inline: 0; }
+
+.at-section-label { font-size: 11px; letter-spacing: .18em; text-transform: uppercase; opacity: .75; margin: 26px 0 4px; }
+
+// Zurück-Link/Buttons in Glas
+.at-backbtn { width: 34px; height: 34px; border-radius: 50%; display: grid; place-items: center; color: #fff;
+  background: var(--at-glass-bg); border: 1px solid var(--at-glass-brd); text-decoration: none; flex: 0 0 auto; }
+
+// Sekundär-Aktionen unten
+.at-actions { margin-top: 22px; display: flex; flex-direction: column; gap: 10px; }
+.at-action { display: flex; align-items: center; gap: 10px; padding: 13px 15px; border-radius: var(--at-r-md); color: #fff; text-decoration: none;
+  background: var(--at-glass-bg); border: 1px solid var(--at-glass-brd); backdrop-filter: blur(10px); font-size: 14px; font-weight: 500; }
+.at-action:hover { background: rgba(255,255,255,.22); }
+
+// Desktop: die App-Spalte bekommt einen weichen Rahmen, der Himmel bleibt Vollbild dahinter
+@media (min-width: 620px) {
+  .at-page::before { content:""; position: fixed; inset: 0; pointer-events: none;
+    box-shadow: inset 0 0 140px rgba(0,0,0,.28); }
+}

--- a/assets/scss/atmosphaere.scss
+++ b/assets/scss/atmosphaere.scss
@@ -218,3 +218,23 @@
 @keyframes at-spin { to { transform: rotate(360deg); } }
 .at-geo-error { margin-top: 10px; font-size: 12.5px; color: #ffd9d0; }
 @media (prefers-reduced-motion: reduce) { .at-cta.is-loading::after { animation: none; } }
+
+// ---------- Karte (Leaflet, in die Atmosphäre eingepasst) -------------------
+@import "~leaflet/dist/leaflet.css";
+
+.at-map {
+  height: 240px; width: 100%; border-radius: var(--at-r-lg); overflow: hidden;
+  border: 1px solid var(--at-glass-brd); background: #12203a; z-index: 0;
+}
+// OSM-Kacheln in einen dunklen, entsättigten Look bringen (passt zum Himmel,
+// bleibt bei OSM als bereits im Datenschutz genanntem Dienst).
+.at-map .leaflet-tile {
+  filter: grayscale(0.55) invert(0.93) contrast(0.9) hue-rotate(180deg) saturate(0.85) brightness(0.95);
+}
+.at-map .leaflet-container { background: #12203a; font-family: var(--at-sans); }
+.at-map .leaflet-control-attribution {
+  background: rgba(10, 16, 26, 0.6); color: rgba(255, 255, 255, 0.6); backdrop-filter: blur(4px);
+  a { color: rgba(255, 255, 255, 0.75); }
+}
+.at-map .leaflet-bar a { background: rgba(20, 28, 42, 0.85); color: #fff; border-color: rgba(255,255,255,.15); }
+.at-map .leaflet-popup-content-wrapper, .at-map .leaflet-popup-tip { background: #1a2740; color: #fff; }

--- a/src/Controller/AtmosphaerePreviewController.php
+++ b/src/Controller/AtmosphaerePreviewController.php
@@ -2,18 +2,24 @@
 
 namespace App\Controller;
 
+use App\Air\Geocoding\Guesser\CityGuesserInterface;
+use App\Air\Geocoding\RequestConverter\RequestConverterInterface;
 use App\Air\PollutionDataFactory\PollutionDataFactory;
+use App\Air\PollutionDataFactory\PollutionDataFactoryInterface;
+use App\Entity\City;
 use App\Entity\Station;
+use Doctrine\Persistence\ManagerRegistry;
 use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Nicht-öffentliche Design-Vorschau für die Neugestaltung „Atmosphäre" (Prototyp 01).
- * Rendert die neuen Screens im echten Asset-Build, ohne die Live-Seiten zu verändern.
- * Bewusst noindex; wird nach Abschluss der Migration entfernt.
+ * Rendert die neuen Screens im echten Asset-Build mit echten Daten — zur Verifikation vor
+ * der Live-Umstellung. Bewusst noindex; wird nach Abschluss der Migration entfernt.
  */
 final class AtmosphaerePreviewController extends AbstractController
 {
@@ -23,9 +29,12 @@ final class AtmosphaerePreviewController extends AbstractController
         return $this->noindex($this->render('Atmosphaere/preview.html.twig'));
     }
 
-    /**
-     * Neue Stationsseite mit ECHTEN Daten — zur Verifikation vor der Live-Umstellung.
-     */
+    #[Route('/vorschau/start', name: 'atmosphaere_preview_start', methods: ['GET'])]
+    public function start(): Response
+    {
+        return $this->noindex($this->render('Atmosphaere/start.html.twig'));
+    }
+
     #[Route('/vorschau/station/{stationCode}', name: 'atmosphaere_preview_station', methods: ['GET'])]
     public function station(
         #[MapEntity(expr: 'repository.findOneByStationCode(stationCode)')] Station $station,
@@ -38,6 +47,33 @@ final class AtmosphaerePreviewController extends AbstractController
         return $this->noindex($this->render('Atmosphaere/station.html.twig', [
             'station' => $station,
             'pollutantList' => $viewModelList,
+        ]));
+    }
+
+    #[Route('/vorschau/result', name: 'atmosphaere_preview_result', methods: ['GET'])]
+    public function result(
+        Request $request,
+        RequestConverterInterface $requestConverter,
+        PollutionDataFactoryInterface $pollutionDataFactory,
+        CityGuesserInterface $cityGuesser,
+        SeoPageInterface $seoPage,
+        ManagerRegistry $doctrine,
+    ): Response {
+        $coord = $requestConverter->getCoordByRequest($request);
+        if (!$coord) {
+            return $this->noindex($this->render('Atmosphaere/start.html.twig'));
+        }
+
+        $viewModelList = $pollutionDataFactory->setCoord($coord)->createDecoratedPollutantList();
+        $cityName = $cityGuesser->guess($coord);
+        $city = $cityName ? $doctrine->getRepository(City::class)->findOneByName($cityName) : null;
+        $seoPage->setTitle('Aktuelle Luftmesswerte aus deiner Umgebung — luft.jetzt');
+
+        return $this->noindex($this->render('Atmosphaere/result.html.twig', [
+            'pollutantList' => $viewModelList,
+            'cityName' => $cityName,
+            'coord' => $coord,
+            'city' => $city,
         ]));
     }
 

--- a/src/Controller/AtmosphaerePreviewController.php
+++ b/src/Controller/AtmosphaerePreviewController.php
@@ -5,13 +5,10 @@ namespace App\Controller;
 use App\Air\Geocoding\Guesser\CityGuesserInterface;
 use App\Air\Geocoding\RequestConverter\RequestConverterInterface;
 use App\Air\PollutionDataFactory\PollutionDataFactory;
-use App\Air\PollutionDataFactory\PollutionDataFactoryInterface;
 use App\Entity\City;
 use App\Entity\Station;
-use Doctrine\Persistence\ManagerRegistry;
 use Sonata\SeoBundle\Seo\SeoPageInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -50,14 +47,29 @@ final class AtmosphaerePreviewController extends AbstractController
         ]));
     }
 
+    #[Route('/vorschau/city/{citySlug}', name: 'atmosphaere_preview_city', methods: ['GET'])]
+    public function city(
+        #[MapEntity(expr: 'repository.findOneBySlug(citySlug)')] City $city,
+        PollutionDataFactory $pollutionDataFactory,
+        SeoPageInterface $seoPage,
+    ): Response {
+        $stationList = $this->getStationListForCity($city);
+        $seoPage->setTitle(sprintf('Luftqualität in %s — luft.jetzt', $city->getName()));
+
+        return $this->noindex($this->render('Atmosphaere/city.html.twig', [
+            'city' => $city,
+            'stationList' => $stationList,
+            'stationBoxList' => $this->createViewModelListForStationList($pollutionDataFactory, $stationList),
+        ]));
+    }
+
     #[Route('/vorschau/result', name: 'atmosphaere_preview_result', methods: ['GET'])]
     public function result(
         Request $request,
         RequestConverterInterface $requestConverter,
-        PollutionDataFactoryInterface $pollutionDataFactory,
+        PollutionDataFactory $pollutionDataFactory,
         CityGuesserInterface $cityGuesser,
         SeoPageInterface $seoPage,
-        ManagerRegistry $doctrine,
     ): Response {
         $coord = $requestConverter->getCoordByRequest($request);
         if (!$coord) {
@@ -66,7 +78,7 @@ final class AtmosphaerePreviewController extends AbstractController
 
         $viewModelList = $pollutionDataFactory->setCoord($coord)->createDecoratedPollutantList();
         $cityName = $cityGuesser->guess($coord);
-        $city = $cityName ? $doctrine->getRepository(City::class)->findOneByName($cityName) : null;
+        $city = $cityName ? $this->findCityForName($cityName) : null;
         $seoPage->setTitle('Aktuelle Luftmesswerte aus deiner Umgebung — luft.jetzt');
 
         return $this->noindex($this->render('Atmosphaere/result.html.twig', [

--- a/src/Controller/AtmosphaerePreviewController.php
+++ b/src/Controller/AtmosphaerePreviewController.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Nicht-öffentliche Design-Vorschau für die Neugestaltung „Atmosphäre" (Prototyp 01).
+ * Rendert den neuen Ergebnis-Screen im echten Asset-Build, ohne die Live-Seiten zu verändern.
+ * Bewusst noindex; wird nach Abschluss der Migration entfernt.
+ */
+final class AtmosphaerePreviewController extends AbstractController
+{
+    #[Route('/vorschau/atmosphaere', name: 'atmosphaere_preview', methods: ['GET'])]
+    public function index(): Response
+    {
+        $response = $this->render('Atmosphaere/preview.html.twig');
+        $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+
+        return $response;
+    }
+}

--- a/src/Controller/AtmosphaerePreviewController.php
+++ b/src/Controller/AtmosphaerePreviewController.php
@@ -2,13 +2,17 @@
 
 namespace App\Controller;
 
+use App\Air\PollutionDataFactory\PollutionDataFactory;
+use App\Entity\Station;
+use Sonata\SeoBundle\Seo\SeoPageInterface;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Nicht-öffentliche Design-Vorschau für die Neugestaltung „Atmosphäre" (Prototyp 01).
- * Rendert den neuen Ergebnis-Screen im echten Asset-Build, ohne die Live-Seiten zu verändern.
+ * Rendert die neuen Screens im echten Asset-Build, ohne die Live-Seiten zu verändern.
  * Bewusst noindex; wird nach Abschluss der Migration entfernt.
  */
 final class AtmosphaerePreviewController extends AbstractController
@@ -16,7 +20,29 @@ final class AtmosphaerePreviewController extends AbstractController
     #[Route('/vorschau/atmosphaere', name: 'atmosphaere_preview', methods: ['GET'])]
     public function index(): Response
     {
-        $response = $this->render('Atmosphaere/preview.html.twig');
+        return $this->noindex($this->render('Atmosphaere/preview.html.twig'));
+    }
+
+    /**
+     * Neue Stationsseite mit ECHTEN Daten — zur Verifikation vor der Live-Umstellung.
+     */
+    #[Route('/vorschau/station/{stationCode}', name: 'atmosphaere_preview_station', methods: ['GET'])]
+    public function station(
+        #[MapEntity(expr: 'repository.findOneByStationCode(stationCode)')] Station $station,
+        PollutionDataFactory $pollutionDataFactory,
+        SeoPageInterface $seoPage,
+    ): Response {
+        $viewModelList = $pollutionDataFactory->setStation($station)->createDecoratedPollutantList();
+        $seoPage->setTitle(sprintf('Luftqualität an der Station %s — luft.jetzt', $station->getStationCode()));
+
+        return $this->noindex($this->render('Atmosphaere/station.html.twig', [
+            'station' => $station,
+            'pollutantList' => $viewModelList,
+        ]));
+    }
+
+    private function noindex(Response $response): Response
+    {
         $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
 
         return $response;

--- a/src/Controller/CityController.php
+++ b/src/Controller/CityController.php
@@ -25,7 +25,7 @@ class CityController extends AbstractController
         $stationList = $this->getStationListForCity($city);
         $stationViewModelList = $this->createViewModelListForStationList($pollutionDataFactory, $stationList);
 
-        return $this->render('City/show.html.twig', [
+        return $this->render('Atmosphaere/city.html.twig', [
             'city' => $city,
             'stationList' => $stationList,
             'stationBoxList' => $stationViewModelList,

--- a/src/Controller/DisplayController.php
+++ b/src/Controller/DisplayController.php
@@ -49,7 +49,7 @@ class DisplayController extends AbstractController
             $city = null;
         }
 
-        return $this->render('Default/display.html.twig', [
+        return $this->render('Atmosphaere/result.html.twig', [
             'pollutantList' => $viewModelList,
             'cityName' => $cityName,
             'coord' => $coord,

--- a/src/Controller/FrontpageController.php
+++ b/src/Controller/FrontpageController.php
@@ -14,6 +14,6 @@ class FrontpageController extends AbstractController
             ->setTitle('Aktuelle Schadstoffwerte aus Luftmessstationen in deiner Umgebung: Stickstoffdioxid, Feinstaub und Ozon')
             ->setDescription('Luft.jetzt zeigt dir aktuelle Messwerte aus Luftmessstationen deiner Umgebung. Informiere dich über Stickstoffdioxid, Feinstaub und Ozon');;
 
-        return $this->render('Default/select.html.twig');
+        return $this->render('Atmosphaere/start.html.twig');
     }
 }

--- a/src/Controller/StationController.php
+++ b/src/Controller/StationController.php
@@ -33,7 +33,9 @@ class StationController extends AbstractController
             $seoPage->setTitle(sprintf('Luftmesswerte für die Station %s', $station->getStationCode()));
         }
 
-        return $this->render('Default/station.html.twig', [
+        // Neugestaltung „Atmosphäre": Stationsseite im neuen Look (verifiziert über
+        // /vorschau/station/… vor der Umstellung). Alte Bootstrap-Ansicht: Default/station.html.twig.
+        return $this->render('Atmosphaere/station.html.twig', [
             'station' => $station,
             'pollutantList' => $viewModelList,
         ]);

--- a/src/Twig/Extension/AtmosphaereTwigExtension.php
+++ b/src/Twig/Extension/AtmosphaereTwigExtension.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Helfer für die Neugestaltung „Atmosphäre": bildet die Gesamt-Belastungsstufe (0–6, aus
+ * {@see PollutionLevelTwigExtension::maxPollutionLevel()}) auf die fünf Himmel-Zustände ab und
+ * liefert das dazugehörige Urteil samt kurzer Empfehlung.
+ *
+ * Interne App-Skala: 0 = keine Daten (weiß), 1–2 grün, 3–4 gelb, 5–6 rot.
+ * Atmosphäre-Himmel: 1 sehr gut · 2 gut · 3 mäßig · 4 schlecht · 5 sehr schlecht · 0 Idle.
+ */
+class AtmosphaereTwigExtension extends AbstractExtension
+{
+    private const array SKY_LEVEL = [0 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 3, 5 => 4, 6 => 5];
+
+    private const array VERDICT = [
+        0 => 'Keine Daten',
+        1 => 'Sehr gut',
+        2 => 'Gut',
+        3 => 'Mäßig',
+        4 => 'Schlecht',
+        5 => 'Sehr schlecht',
+    ];
+
+    private const array SUBTITLE = [
+        0 => 'Für diesen Ort liegen gerade keine aktuellen Messwerte vor.',
+        1 => 'Beste Luft — unbeschwert draußen.',
+        2 => 'Unbedenklich — genieß die frische Luft.',
+        3 => 'Für Empfindliche: Anstrengung im Freien etwas reduzieren.',
+        4 => 'Anstrengende Aktivitäten im Freien besser meiden.',
+        5 => 'Draußen möglichst meiden und Fenster geschlossen halten.',
+    ];
+
+    #[\Override]
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('at_sky_level', $this->skyLevel(...)),
+            new TwigFunction('at_verdict', $this->verdict(...)),
+            new TwigFunction('at_subtitle', $this->subtitle(...)),
+            new TwigFunction('at_scale_position', $this->scalePosition(...)),
+        ];
+    }
+
+    /** Interne Stufe 0–6 → Himmel-Zustand 0–5. */
+    public function skyLevel(int $pollutionLevel): int
+    {
+        return self::SKY_LEVEL[max(0, min(6, $pollutionLevel))] ?? 0;
+    }
+
+    /** Urteil aus dem Himmel-Zustand (0–5). */
+    public function verdict(int $skyLevel): string
+    {
+        return self::VERDICT[$skyLevel] ?? self::VERDICT[0];
+    }
+
+    public function subtitle(int $skyLevel): string
+    {
+        return self::SUBTITLE[$skyLevel] ?? self::SUBTITLE[0];
+    }
+
+    /** Position des Skalenmarkers in Prozent (Himmel-Zustand 1–5 → 10 %…90 %). */
+    public function scalePosition(int $skyLevel): int
+    {
+        return match ($skyLevel) {
+            1 => 10, 2 => 32, 3 => 52, 4 => 72, 5 => 92,
+            default => 50,
+        };
+    }
+}

--- a/templates/Atmosphaere/base.html.twig
+++ b/templates/Atmosphaere/base.html.twig
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html {{ sonata_seo_html_attributes() }}>
+<head {{ sonata_seo_head_attributes() }}>
+    {{ sonata_seo_title() }}
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="initial-scale=1, width=device-width, viewport-fit=cover">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="{% block theme_color %}#173a63{% endblock %}">
+
+    {{ sonata_seo_metadatas() }}
+    {{ sonata_seo_link_canonical() }}
+    {{ sonata_seo_lang_alternates() }}
+
+    {% block stylesheets %}{{ encore_entry_link_tags('css/atmosphaere') }}{% endblock %}
+</head>
+<body class="at-page at-sky {% block sky_class %}at-idle{% endblock %}">
+    <div class="at-shell">
+        <header class="at-topbar">
+            <a class="at-brand" href="{{ path('display') }}">luft<span>.jetzt</span></a>
+            <div class="at-topbar__actions">
+                <a class="at-iconbtn" href="{{ path('display') }}" aria-label="Ort suchen">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg>
+                </a>
+            </div>
+        </header>
+
+        {% block content %}{% endblock %}
+
+        <footer class="at-foot" style="text-align:left; margin-top:auto; padding-top:34px;">
+            {% block attribution %}
+                Amtliche Messwerte des <a href="https://www.umweltbundesamt.de/">Umweltbundesamts</a>,
+                ergänzt von <a href="https://sensor.community/">Sensor.Community</a>.
+            {% endblock %}
+            <div style="margin-top:10px; opacity:.85;">
+                <a href="{{ path('impress') }}">Impressum</a> ·
+                <a href="{{ path('privacy') }}">Datenschutz</a> ·
+                <a href="{{ path('display') }}">Startseite</a>
+            </div>
+        </footer>
+    </div>
+
+    {% block javascripts %}{% endblock %}
+</body>
+</html>

--- a/templates/Atmosphaere/base.html.twig
+++ b/templates/Atmosphaere/base.html.twig
@@ -17,6 +17,7 @@
 </head>
 <body class="at-page at-sky {% block sky_class %}at-idle{% endblock %}">
     <div class="at-shell">
+        {% block topbar %}
         <header class="at-topbar">
             <a class="at-brand" href="{{ path('display') }}">luft<span>.jetzt</span></a>
             <div class="at-topbar__actions">
@@ -25,6 +26,7 @@
                 </a>
             </div>
         </header>
+        {% endblock %}
 
         {% block content %}{% endblock %}
 
@@ -41,6 +43,6 @@
         </footer>
     </div>
 
-    {% block javascripts %}{% endblock %}
+    {% block javascripts %}{{ encore_entry_script_tags('js/atmosphaere') }}{% endblock %}
 </body>
 </html>

--- a/templates/Atmosphaere/city.html.twig
+++ b/templates/Atmosphaere/city.html.twig
@@ -1,0 +1,51 @@
+{% extends 'Atmosphaere/base.html.twig' %}
+
+{% set cityMax = 0 %}
+{% for station in stationList %}
+    {% if stationBoxList[station.stationCode] is defined and stationBoxList[station.stationCode]|length > 0 %}
+        {% set cityMax = max(cityMax, max_pollution_level(stationBoxList[station.stationCode])) %}
+    {% endif %}
+{% endfor %}
+{% set sky = at_sky_level(cityMax) %}
+
+{% block sky_class %}at-lv{{ sky > 0 ? sky : 2 }}{% if sky == 0 %} at-idle{% endif %}{% endblock %}
+{% block theme_color %}{{ { 1:'#0e2f5a', 2:'#173a63', 3:'#2c3a54', 4:'#3a2d38', 5:'#241f2b' }[sky] ?? '#1c2145' }}{% endblock %}
+
+{% block content %}
+    <div class="at-hero" style="margin-top:18px;">
+        <div class="at-hero__idx">Luft in {{ city.name }}</div>
+        <div class="at-hero__verdict">{{ at_verdict(sky) }}</div>
+        <div class="at-hero__sub">{{ at_subtitle(sky) }}</div>
+        {% if sky > 0 %}<div class="at-scale"><b style="left:{{ at_scale_position(sky) }}%"></b></div>{% endif %}
+    </div>
+
+    {% set mapStations = [] %}
+    <div class="at-section-label">Messstationen in {{ city.name }}</div>
+    <div class="at-list">
+        {% for station in stationList %}
+            {% if stationBoxList[station.stationCode] is defined and stationBoxList[station.stationCode]|length > 0 %}
+                {% set sLevel = at_sky_level(max_pollution_level(stationBoxList[station.stationCode])) %}
+                {% if station.latitude %}
+                    {% set mapStations = mapStations|merge([{ lat: station.latitude, lon: station.longitude, level: sLevel, name: station.title ?: station.stationCode, code: station.stationCode, url: path('station', { stationCode: station.stationCode }) }]) %}
+                {% endif %}
+                <a class="at-row" href="{{ path('station', { stationCode: station.stationCode }) }}" style="text-decoration:none; color:#fff; grid-template-columns:1fr auto auto;">
+                    <span class="at-row__nm"><i style="background: {{ sLevel > 0 ? 'var(--aqi-' ~ sLevel ~ ')' : 'rgba(255,255,255,.45)' }}"></i>{{ station.title ?: station.stationCode }}</span>
+                    <span class="at-row__v" style="font-weight:400; opacity:.85; font-size:12.5px;">{{ at_verdict(sLevel) }}</span>
+                    <span style="opacity:.6;">›</span>
+                </a>
+            {% endif %}
+        {% else %}
+            <p style="opacity:.85; padding:14px 0;">Für {{ city.name }} liegen gerade keine aktuellen Messwerte vor.</p>
+        {% endfor %}
+    </div>
+
+    {% if mapStations is not empty %}
+        <div class="at-section-label">Karte</div>
+        <div class="at-map" data-at-map data-at-stations="{{ mapStations|json_encode|e('html_attr') }}"></div>
+    {% endif %}
+
+    {% if city.description %}
+        <div class="at-section-label">Über {{ city.name }}</div>
+        <p style="opacity:.9; font-size:14px; line-height:1.6;">{{ city.description|nl2br }}</p>
+    {% endif %}
+{% endblock %}

--- a/templates/Atmosphaere/preview.html.twig
+++ b/templates/Atmosphaere/preview.html.twig
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>luft.jetzt · Atmosphäre — Live-Vorschau</title>
+    {{ encore_entry_link_tags('css/atmosphaere') }}
+    <style>
+        :root { color-scheme: dark; }
+        body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+               background: radial-gradient(120% 70% at 80% -10%, #17314f, #0b131d 60%); color: #dfe8f0; min-height: 100vh; }
+        .pv-wrap { width: min(1080px, 92vw); margin-inline: auto; padding: 48px 0 90px; }
+        .pv-head .ey { font-size: 12.5px; letter-spacing: .16em; text-transform: uppercase; color: #6fd7cc; font-weight: 600; }
+        .pv-head h1 { font-weight: 600; font-size: clamp(26px, 4vw, 40px); margin: 12px 0 0; letter-spacing: -.01em; }
+        .pv-head p { color: #9fb2c4; max-width: 62ch; font-size: 15.5px; }
+        .pv-note { font-size: 12.5px; color: #7e93a6; margin-top: 8px; }
+
+        .pv-switch { display: flex; flex-wrap: wrap; gap: 8px; margin: 26px 0 8px; }
+        .pv-switch button { font: inherit; font-size: 13px; font-weight: 600; color: #cfe0ee; cursor: pointer;
+            background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.14); border-radius: 999px; padding: 8px 15px; display: inline-flex; align-items: center; gap: 8px; transition: .2s; }
+        .pv-switch button:hover { background: rgba(255,255,255,.12); }
+        .pv-switch button[aria-pressed="true"] { border-color: #fff; background: rgba(255,255,255,.16); color: #fff; }
+        .pv-switch button i { width: 11px; height: 11px; border-radius: 50%; }
+
+        .pv-stage { display: flex; flex-wrap: wrap; gap: 30px; align-items: flex-start; margin-top: 26px; }
+        .pv-phone { width: 320px; max-width: 100%; }
+        .pv-phone .pv-screen { height: 592px; border-radius: 40px; overflow: hidden;
+            box-shadow: 0 44px 90px -40px rgba(0,0,0,.7), 0 0 0 9px rgba(255,255,255,.06), 0 0 0 10px rgba(0,0,0,.22); }
+        .pv-phone .pv-tag { text-align: center; font-size: 13px; color: #b9c8d8; margin-top: 13px; font-weight: 600; }
+        .pv-phone .pv-tag span { display: block; font-weight: 400; color: #7e93a6; font-size: 11.5px; margin-top: 2px; }
+
+        .pv-foot { margin-top: 44px; border-top: 1px solid rgba(255,255,255,.1); padding-top: 22px; color: #9fb2c4; font-size: 14px; }
+        .pv-foot code { font-family: var(--at-mono); font-size: .9em; color: #b9c8d8; }
+        a { color: #6fd7cc; }
+    </style>
+</head>
+<body>
+<div class="pv-wrap">
+    <div class="pv-head">
+        <div class="ey">luft.jetzt · Neugestaltung „Atmosphäre"</div>
+        <h1>Live-Vorschau — der Himmel liest die Luft</h1>
+        <p>Der neue Ergebnis-Screen im echten Asset-Build. Wähle eine Stufe und sieh, wie sich der ganze
+            Himmel verschiebt. Diese Seite ist isoliert (eigener Encore-Entry, <code style="font-family:var(--at-mono)">noindex</code>) und
+            verändert die bestehenden Seiten nicht.</p>
+        <p class="pv-note">Beispiel: Lüneburg · Beispieldaten je Stufe illustrativ.</p>
+    </div>
+
+    <div class="pv-switch" role="group" aria-label="Luftqualitäts-Stufe wählen">
+        <button data-lv="1"><i style="background:var(--aqi-1)"></i>Sehr gut</button>
+        <button data-lv="2" aria-pressed="true"><i style="background:var(--aqi-2)"></i>Gut</button>
+        <button data-lv="3"><i style="background:var(--aqi-3)"></i>Mäßig</button>
+        <button data-lv="4"><i style="background:var(--aqi-4)"></i>Schlecht</button>
+        <button data-lv="5"><i style="background:var(--aqi-5)"></i>Sehr schlecht</button>
+    </div>
+
+    <div class="pv-stage">
+        <!-- interaktiver Ergebnis-Screen -->
+        <div class="pv-phone">
+            <div class="pv-screen">
+                <div class="at-sky at-lv2" id="resultSky">
+                    <div class="at-screen"><div class="at-body">
+                        <div class="at-head">
+                            <div class="at-loc">Lüneburg<small>Messstation · 1,2 km · vor 8 Min</small></div>
+                            <div class="at-iconbtn" aria-hidden="true">
+                                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/></svg>
+                            </div>
+                        </div>
+                        <div class="at-hero">
+                            <div class="at-hero__idx">Luftqualität</div>
+                            <div class="at-hero__verdict" id="rVerdict">Gut</div>
+                            <div class="at-hero__sub" id="rSub">Unbedenklich — nur Ozon ist am Nachmittag leicht erhöht.</div>
+                            <div class="at-scale"><b id="rMarker" style="left:32%"></b></div>
+                        </div>
+                        <div class="at-chips" id="rChips"></div>
+                        <div class="at-foot">Umweltbundesamt · Sensor.Community · BfS</div>
+                    </div></div>
+                </div>
+            </div>
+            <div class="pv-tag">Ergebnis <span>interaktiv — Himmel folgt dem Gesamtindex</span></div>
+        </div>
+
+        <!-- Station-Detail (statisch, Stufe „gut") -->
+        <div class="pv-phone">
+            <div class="pv-screen">
+                <div class="at-sky at-lv2">
+                    <div class="at-screen"><div class="at-body">
+                        <div class="at-head" style="gap:12px; justify-content:flex-start">
+                            <div class="at-iconbtn" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="M15 18l-6-6 6-6"/></svg></div>
+                            <div class="at-loc">Messstation Lüneburg</div>
+                        </div>
+                        <div style="margin:18px 0 6px; display:flex; align-items:baseline; gap:12px">
+                            <div style="font-size:34px; font-weight:300">Gut</div>
+                            <div style="font-size:12px; opacity:.85">Index 2/5 · 1,2 km · Umweltbundesamt</div>
+                        </div>
+                        <div class="at-list" style="font-variant-numeric:tabular-nums">
+                            <div class="at-row"><span class="at-row__nm"><i style="background:var(--aqi-1)"></i>Feinstaub PM<sub>2,5</sub></span><span class="at-row__v">8<small> µg/m³</small></span><svg viewBox="0 0 56 20" preserveAspectRatio="none"><polyline fill="none" stroke="rgba(255,255,255,.85)" stroke-width="1.6" points="0,13 11,11 22,14 33,10 44,12 56,11"/></svg></div>
+                            <div class="at-row"><span class="at-row__nm"><i style="background:var(--aqi-1)"></i>Feinstaub PM<sub>10</sub></span><span class="at-row__v">14<small> µg/m³</small></span><svg viewBox="0 0 56 20" preserveAspectRatio="none"><polyline fill="none" stroke="rgba(255,255,255,.85)" stroke-width="1.6" points="0,12 11,14 22,10 33,13 44,9 56,12"/></svg></div>
+                            <div class="at-row"><span class="at-row__nm"><i style="background:var(--aqi-2)"></i>Stickstoffdioxid</span><span class="at-row__v">21<small> µg/m³</small></span><svg viewBox="0 0 56 20" preserveAspectRatio="none"><polyline fill="none" stroke="rgba(255,255,255,.85)" stroke-width="1.6" points="0,9 11,12 22,8 33,13 44,11 56,12"/></svg></div>
+                            <div class="at-row"><span class="at-row__nm"><i style="background:var(--aqi-3)"></i>Ozon</span><span class="at-row__v">128<small> µg/m³</small></span><svg viewBox="0 0 56 20" preserveAspectRatio="none"><polyline fill="none" stroke="rgba(255,255,255,.9)" stroke-width="1.6" points="0,17 11,14 22,11 33,7 44,6 56,5"/></svg></div>
+                            <div class="at-row"><span class="at-row__nm"><i style="background:var(--aqi-3)"></i>UV-Index</span><span class="at-row__v">5<small> mäßig</small></span><svg viewBox="0 0 56 20" preserveAspectRatio="none"><polyline fill="none" stroke="rgba(255,255,255,.85)" stroke-width="1.6" points="0,18 11,12 22,7 33,6 44,10 56,16"/></svg></div>
+                        </div>
+                        <div class="at-foot" style="text-align:left; margin-top:16px; line-height:1.55">UV-Messwerte: <a href="#">Bundesamt für Strahlenschutz</a> · <a href="#">Tagesverlauf&nbsp;↗</a><br>Luftschadstoffe: Umweltbundesamt &amp; Sensor.Community</div>
+                    </div></div>
+                </div>
+            </div>
+            <div class="pv-tag">Station im Detail <span>Werte, 24-h-Verlauf, Quellen inkl. BfS</span></div>
+        </div>
+
+        <!-- Start / Standort (statisch, Idle) -->
+        <div class="pv-phone">
+            <div class="pv-screen">
+                <div class="at-sky at-idle">
+                    <div class="at-screen"><div class="at-body">
+                        <div class="at-head"><div class="at-loc">luft<span style="opacity:.7">.jetzt</span></div>
+                            <div class="at-iconbtn" aria-hidden="true"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg></div></div>
+                        <div class="at-start__big">Wie ist die Luft<br>gerade bei&nbsp;dir?</div>
+                        <div class="at-search at-glass" style="margin-top:22px">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" opacity=".8"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg>
+                            <input placeholder="Ort, Postleitzahl oder Station" readonly>
+                        </div>
+                        <button class="at-cta" style="margin-top:12px"><span aria-hidden="true">📍</span>&nbsp; Meinen Standort verwenden</button>
+                        <div class="at-start__hint">Amtliche Messwerte des Umweltbundesamts, ergänzt von Sensor.Community.</div>
+                    </div></div>
+                </div>
+            </div>
+            <div class="pv-tag">Start &amp; Standort <span>ruhiger Dämmerungshimmel als Idle</span></div>
+        </div>
+    </div>
+
+    <div class="pv-foot">
+        Nächste Etappe (M2): dieselben Bausteine in die echten Seiten (Start → Stadt → Station → Karte),
+        Ableitung des Himmel-Zustands aus dem Gesamtindex, Ablösung des Bootstrap-Layouts.
+        Design-System: <code>assets/scss/atmosphaere.scss</code>.
+    </div>
+</div>
+
+<script>
+    (function () {
+        var data = {
+            1: { verdict: "Sehr gut", sub: "Beste Luft — unbeschwert draußen.", marker: 10,
+                 chips: [["PM₂,₅","4","µg/m³",1],["PM₁₀","7","µg/m³",1],["NO₂","9","µg/m³",1],["Ozon","48","",1]] },
+            2: { verdict: "Gut", sub: "Unbedenklich — nur Ozon ist am Nachmittag leicht erhöht.", marker: 32,
+                 chips: [["PM₂,₅","8","µg/m³",1],["PM₁₀","14","µg/m³",1],["NO₂","21","µg/m³",2],["Ozon","128","",3]] },
+            3: { verdict: "Mäßig", sub: "Empfindliche sollten Anstrengung im Freien reduzieren.", marker: 52,
+                 chips: [["PM₂,₅","18","µg/m³",2],["PM₁₀","32","µg/m³",2],["NO₂","64","µg/m³",3],["Ozon","168","",3]] },
+            4: { verdict: "Schlecht", sub: "Anstrengende Aktivitäten im Freien besser meiden.", marker: 72,
+                 chips: [["PM₂,₅","42","µg/m³",4],["PM₁₀","78","µg/m³",4],["NO₂","110","µg/m³",3],["Ozon","210","",4]] },
+            5: { verdict: "Sehr schlecht", sub: "Draußen möglichst meiden, Fenster geschlossen halten.", marker: 92,
+                 chips: [["PM₂,₅","120","µg/m³",5],["PM₁₀","210","µg/m³",5],["NO₂","150","µg/m³",4],["Ozon","240","",5]] }
+        };
+        var sky = document.getElementById('resultSky');
+        var verdict = document.getElementById('rVerdict');
+        var sub = document.getElementById('rSub');
+        var marker = document.getElementById('rMarker');
+        var chips = document.getElementById('rChips');
+        var buttons = document.querySelectorAll('.pv-switch button');
+
+        function render(lv) {
+            var d = data[lv];
+            sky.className = 'at-sky at-lv' + lv;
+            verdict.textContent = d.verdict;
+            sub.textContent = d.sub;
+            marker.style.left = d.marker + '%';
+            chips.innerHTML = d.chips.map(function (c) {
+                var unit = c[2] ? '<small> ' + c[2] + '</small>' : '';
+                return '<div class="at-chip at-glass"><div class="at-chip__k">' + c[0] + '</div>' +
+                       '<div class="at-chip__v"><span class="at-dot" style="background:var(--aqi-' + c[3] + ')"></span>' + c[1] + unit + '</div></div>';
+            }).join('');
+            buttons.forEach(function (b) { b.setAttribute('aria-pressed', b.dataset.lv === String(lv) ? 'true' : 'false'); });
+        }
+        buttons.forEach(function (b) { b.addEventListener('click', function () { render(b.dataset.lv); }); });
+        render(2);
+    })();
+</script>
+</body>
+</html>

--- a/templates/Atmosphaere/result.html.twig
+++ b/templates/Atmosphaere/result.html.twig
@@ -1,0 +1,57 @@
+{% extends 'Atmosphaere/base.html.twig' %}
+
+{% set maxLevel = max_pollution_level(pollutantList) %}
+{% set sky = at_sky_level(maxLevel) %}
+
+{% block sky_class %}at-lv{{ sky > 0 ? sky : 2 }}{% if sky == 0 %} at-idle{% endif %}{% endblock %}
+{% block theme_color %}{{ { 1:'#0e2f5a', 2:'#173a63', 3:'#2c3a54', 4:'#3a2d38', 5:'#241f2b' }[sky] ?? '#1c2145' }}{% endblock %}
+
+{% block content %}
+    <div class="at-hero" style="margin-top:20px;">
+        <div class="at-hero__idx">Luftqualität{% if city %} · {{ city.name }}{% elseif cityName %} · {{ cityName }}{% else %} in deiner Umgebung{% endif %}</div>
+        <div class="at-hero__verdict">{{ at_verdict(sky) }}</div>
+        <div class="at-hero__sub">{{ at_subtitle(sky) }}</div>
+        {% if sky > 0 %}<div class="at-scale"><b style="left:{{ at_scale_position(sky) }}%"></b></div>{% endif %}
+    </div>
+
+    <div class="at-chips">
+        {% for group in pollutantList %}
+            {% for vm in group %}
+                {% set dl = at_sky_level(vm.pollutionLevel) %}
+                <a class="at-chip at-glass" href="{{ path('station', { stationCode: vm.station.stationCode }) }}"
+                   style="text-decoration:none; color:#fff;"
+                   title="{{ vm.pollutant.name }} · Station {{ vm.station.title ?: vm.station.stationCode }}">
+                    <div class="at-chip__k">{{ (vm.pollutant.shortNameHtml ?: vm.pollutant.name)|raw }}</div>
+                    <div class="at-chip__v"><span class="at-dot" style="background: {{ dl > 0 ? 'var(--aqi-' ~ dl ~ ')' : 'rgba(255,255,255,.45)' }}"></span>{{ vm.data.value|number_format(vm.pollutant.decimals, ',', '.') }}<small> {{ vm.pollutant.unitHtml|raw }}</small></div>
+                </a>
+            {% endfor %}
+        {% else %}
+            <p style="opacity:.85;">In deiner Umgebung wurden keine aktuellen Messwerte gefunden.</p>
+        {% endfor %}
+    </div>
+
+    <div class="at-section-label">Messstationen in der Nähe</div>
+    <div class="at-list">
+        {% set seen = [] %}
+        {% for group in pollutantList %}
+            {% for vm in group %}
+                {% if vm.station.stationCode not in seen %}
+                    {% set seen = seen|merge([vm.station.stationCode]) %}
+                    <a class="at-row" href="{{ path('station', { stationCode: vm.station.stationCode }) }}" style="text-decoration:none; color:#fff; grid-template-columns:1fr auto;">
+                        <span class="at-row__nm">{{ vm.station.title ?: vm.station.stationCode }}</span>
+                        <span class="at-row__v" style="font-weight:400; opacity:.75; font-size:12px;">{{ vm.distance|number_format(1, ',', '.') }} km&nbsp;›</span>
+                    </a>
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    </div>
+
+    {% if city %}
+        <div class="at-actions">
+            <a class="at-action" href="{{ path('show_city', { citySlug: city.slug }) }}">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M3 21h18M6 21V9l6-4 6 4v12"/></svg>
+                Alle Messwerte aus {{ city.name }}
+            </a>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/Atmosphaere/result.html.twig
+++ b/templates/Atmosphaere/result.html.twig
@@ -46,6 +46,19 @@
         {% endfor %}
     </div>
 
+    {% set mapStations = [] %}
+    {% set seenMap = [] %}
+    {% for group in pollutantList %}{% for vm in group %}
+        {% if vm.station.stationCode not in seenMap and vm.station.latitude %}
+            {% set seenMap = seenMap|merge([vm.station.stationCode]) %}
+            {% set mapStations = mapStations|merge([{ lat: vm.station.latitude, lon: vm.station.longitude, level: at_sky_level(vm.pollutionLevel), name: vm.station.title ?: vm.station.stationCode, code: vm.station.stationCode, url: path('station', { stationCode: vm.station.stationCode }) }]) %}
+        {% endif %}
+    {% endfor %}{% endfor %}
+    {% if mapStations is not empty %}
+        <div class="at-section-label">Karte</div>
+        <div class="at-map" data-at-map data-at-stations="{{ mapStations|json_encode|e('html_attr') }}" data-at-me="{{ { lat: coord.latitude, lon: coord.longitude }|json_encode|e('html_attr') }}"></div>
+    {% endif %}
+
     {% if city %}
         <div class="at-actions">
             <a class="at-action" href="{{ path('show_city', { citySlug: city.slug }) }}">

--- a/templates/Atmosphaere/start.html.twig
+++ b/templates/Atmosphaere/start.html.twig
@@ -1,0 +1,26 @@
+{% extends 'Atmosphaere/base.html.twig' %}
+
+{% block sky_class %}at-idle{% endblock %}
+{% block theme_color %}#1c2145{% endblock %}
+
+{% block topbar %}
+    <header class="at-topbar"><a class="at-brand" href="{{ path('display') }}">luft<span>.jetzt</span></a></header>
+{% endblock %}
+
+{% block content %}
+    <div class="at-start__big" style="margin-top:52px;">Wie ist die Luft<br>gerade bei&nbsp;dir?</div>
+
+    <div class="at-searchbox" style="margin-top:22px;">
+        <div class="at-search at-glass">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" opacity=".8"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg>
+            <input type="search" data-at-search autocomplete="off" placeholder="Ort, Postleitzahl oder Station"
+                   aria-label="Ort, Postleitzahl oder Station suchen">
+        </div>
+        <div class="at-results" data-at-results hidden></div>
+    </div>
+
+    <button type="button" class="at-cta" data-at-geolocate style="margin-top:12px;">
+        <span aria-hidden="true">📍</span>&nbsp; Meinen Standort verwenden
+    </button>
+    <p class="at-geo-error" data-at-geo-error hidden></p>
+{% endblock %}

--- a/templates/Atmosphaere/station.html.twig
+++ b/templates/Atmosphaere/station.html.twig
@@ -50,6 +50,12 @@
         {% endfor %}
     </div>
 
+    {% if station.latitude and station.longitude %}
+        {% set mapStations = [{ lat: station.latitude, lon: station.longitude, level: sky, name: 'Messstation ' ~ (station.title ?: station.stationCode), code: station.stationCode }] %}
+        <div class="at-section-label">Standort</div>
+        <div class="at-map" data-at-map data-at-stations="{{ mapStations|json_encode|e('html_attr') }}"></div>
+    {% endif %}
+
     <div class="at-actions">
         {% if station.city %}
             <a class="at-action" href="{{ path('show_city', { citySlug: station.city.slug }) }}">

--- a/templates/Atmosphaere/station.html.twig
+++ b/templates/Atmosphaere/station.html.twig
@@ -1,0 +1,72 @@
+{% extends 'Atmosphaere/base.html.twig' %}
+
+{% set maxLevel = max_pollution_level(pollutantList) %}
+{% set sky = at_sky_level(maxLevel) %}
+
+{% block sky_class %}at-lv{{ sky > 0 ? sky : 2 }}{% if sky == 0 %} at-idle{% endif %}{% endblock %}
+{% block theme_color %}{{ { 1:'#0e2f5a', 2:'#173a63', 3:'#2c3a54', 4:'#3a2d38', 5:'#241f2b' }[sky] ?? '#1c2145' }}{% endblock %}
+
+{% block content %}
+    <div class="at-detailhead">
+        <a class="at-backbtn" href="{% if station.city %}{{ path('show_city', { citySlug: station.city.slug }) }}{% else %}{{ path('display') }}{% endif %}" aria-label="Zurück">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="M15 18l-6-6 6-6"/></svg>
+        </a>
+        <div class="at-title">Messstation {{ station.title ?: station.stationCode }}</div>
+    </div>
+
+    <div class="at-mini-hero">
+        <div class="at-word">{{ at_verdict(sky) }}</div>
+        <div class="at-meta">
+            {% if sky > 0 %}Index {{ sky }}/5 · {% endif %}
+            Station {{ station.stationCode }}{% if station.network %} · {{ station.network.name }}{% endif %}
+        </div>
+        {% if sky > 0 %}<div class="at-scale"><b style="left:{{ at_scale_position(sky) }}%"></b></div>{% endif %}
+        <p class="at-hero__sub" style="margin:12px 0 0; max-width:34ch;">{{ at_subtitle(sky) }}</p>
+    </div>
+
+    <div class="at-section-label">Messwerte</div>
+    <div class="at-list">
+        {% for group in pollutantList %}
+            {% for vm in group %}
+                {% set dl = at_sky_level(vm.pollutionLevel) %}
+                <div class="at-row">
+                    <span class="at-row__nm">
+                        <i style="background: {{ dl > 0 ? 'var(--aqi-' ~ dl ~ ')' : 'rgba(255,255,255,.45)' }}"></i>{{ vm.pollutant.name }}
+                    </span>
+                    <span class="at-row__v">{{ vm.data.value|number_format(vm.pollutant.decimals, ',', '.') }} <small>{{ vm.pollutant.unitHtml|raw }}</small></span>
+                    <span style="font-size:10.5px; opacity:.7; text-align:right;">
+                        <time data-time-ago-timestamp="{{ vm.data.dateTime|date('U') }}">{{ vm.data.dateTime|date('H:i', 'Europe/Berlin') }}</time>
+                    </span>
+                </div>
+                {% if vm.pollutant.identifier == 'uvindex' %}
+                    {% set bfsUrl = bfs_uv_station_url(station.stationCode) %}
+                    <div style="grid-column:1/-1; font-size:11px; opacity:.8; margin:-4px 0 2px 16px;">
+                        UV vom <a href="https://www.bfs.de/DE/themen/opt/uv/uv-index/" target="_blank" rel="noopener">Bundesamt für Strahlenschutz</a>{% if bfsUrl %} · <a href="{{ bfsUrl }}" target="_blank" rel="noopener">Tagesverlauf&nbsp;↗</a>{% endif %}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        {% else %}
+            <p style="opacity:.85; padding:14px 0;">Für diese Station liegen gerade keine aktuellen Messwerte vor.</p>
+        {% endfor %}
+    </div>
+
+    <div class="at-actions">
+        {% if station.city %}
+            <a class="at-action" href="{{ path('show_city', { citySlug: station.city.slug }) }}">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M3 21h18M6 21V9l6-4 6 4v12"/></svg>
+                Weitere Messwerte aus {{ station.city.name }}
+            </a>
+        {% endif %}
+        {% if feature('station_history') %}
+            <a class="at-action" href="{{ path('station_history', { stationCode: station.stationCode }) }}">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M3 3v18h18M7 14l4-4 3 3 5-6"/></svg>
+                Frühere Messwerte dieser Station
+            </a>
+        {% endif %}
+    </div>
+{% endblock %}
+
+{% block attribution %}
+    Messwerte des <a href="https://www.umweltbundesamt.de/">Umweltbundesamts</a>, ergänzt von
+    <a href="https://sensor.community/">Sensor.Community</a>{% if station.provider == 'ld' %} (Station via Sensor.Community){% endif %}.
+{% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,6 +17,7 @@ Encore
     .addEntry('js/datatables', './assets/js/datatables.js')
     .addStyleEntry('css/app', './assets/scss/app.scss')
     .addStyleEntry('css/atmosphaere', './assets/scss/atmosphaere.scss')
+    .addEntry('js/atmosphaere', './assets/js/atmosphaere.js')
     .enableSassLoader()
     .autoProvidejQuery()
     .copyFiles({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ Encore
     .addEntry('js/app', './assets/js/app.js')
     .addEntry('js/datatables', './assets/js/datatables.js')
     .addStyleEntry('css/app', './assets/scss/app.scss')
+    .addStyleEntry('css/atmosphaere', './assets/scss/atmosphaere.scss')
     .enableSassLoader()
     .autoProvidejQuery()
     .copyFiles({


### PR DESCRIPTION
Der vom Betreiber gewählte Prototyp „Atmosphäre" („Der Himmel liest die Luft") als lauffähige Umsetzung. Bereits live auf luft.jetzt deployt und über Vorschau-Routen verifiziert.

## Neu
- **Design-System** `assets/scss/atmosphaere.scss` — 5 Himmel-Stufen + Idle, AQI-Skala, Sky-Hero, Glas-Chips, Schadstoff-Liste, Vollseiten-Layout. Eigener Encore-Entry (isoliert vom Bootstrap-Frontend).
- **JS-Layer** `assets/js/atmosphaere.js` — Geolocation + schlankes Autocomplete, Leaflet-Karte (dynamisch, OSM mit Dark-Filter, Marker in Index-Farbe), Relativzeit.
- **AtmosphaereTwigExtension** — Gesamtstufe (0–6) → Himmel (1–5/Idle) + Urteil/Empfehlung/Skala.
- Templates: Atmosphaere/{base,start,result,station,city}.html.twig; Vorschau-Routen (noindex).

## Umgestellte Routen
- Startseite → Atmosphaere/start · Geolocation-Ergebnis → Atmosphaere/result · Station → Atmosphaere/station · Stadt → Atmosphaere/city

Folge-Arbeit: Stations-Historie (Feature-Flag aktuell false), optionaler Feinschliff (Tag/Nacht-Himmel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
